### PR TITLE
AWS: Added filters to use only completed snaps & ami's and info return to snapshot

### DIFF
--- a/lib/drivers/docker/docker.go
+++ b/lib/drivers/docker/docker.go
@@ -425,8 +425,8 @@ func (d *Driver) Status(hwaddr string) string {
 	return drivers.StatusNone
 }
 
-func (d *Driver) Snapshot(hwaddr string, full bool) error {
-	return fmt.Errorf("DOCKER: Snapshot not implemented")
+func (d *Driver) Snapshot(hwaddr string, full bool) (string, error) {
+	return "", fmt.Errorf("DOCKER: Snapshot not implemented")
 }
 
 func (d *Driver) Deallocate(hwaddr string) error {

--- a/lib/drivers/driver.go
+++ b/lib/drivers/driver.go
@@ -24,23 +24,30 @@ type ResourceDriver interface {
 	Name() string
 
 	// Give driver configs and check if it's ok
+	// -> config - driver configuration in json format
 	Prepare(config []byte) error
 
 	// Make sure the allocate definition is appropriate
+	// -> definition - describes the driver options to allocate the required resource
 	ValidateDefinition(definition string) error
 
 	// Allocate the resource by definition and returns hw address
-	// * hwaddr - mandatory, needed to identify the resource. If it's a MAC address - it is used to auth in Meta API
-	// * ipaddr - optional, if driver can provide the assigned IP address of the instance
+	// -> definition - describes the driver options to allocate the required resource
+	// -> metadata - user metadata to use during resource allocation
+	// <- hwaddr - mandatory, needed to identify the resource. If it's a MAC address - it is used to auth in Meta API
+	// <- ipaddr - optional, if driver can provide the assigned IP address of the instance
 	Allocate(definition string, metadata map[string]interface{}) (hwaddr, ipaddr string, err error)
 
 	// Get the status of the resource with given hw address
 	Status(hwaddr string) string
 
 	// Makes environment snapshot of the resource with given hw address
-	// * full - will try it's best to make the complete snapshot of the environment, else just non-image data (attached disks)
-	Snapshot(hwaddr string, full bool) error
+	// -> hwaddr - driver identifier of the resource
+	// -> full - will try it's best to make the complete snapshot of the environment, else just non-image data (attached disks)
+	// <- info - where to find the snapshots
+	Snapshot(hwaddr string, full bool) (info string, err error)
 
 	// Deallocate resource with provided hw addr
+	// -> hwaddr - driver identifier of the resource
 	Deallocate(hwaddr string) error
 }

--- a/lib/drivers/vmx/vmx.go
+++ b/lib/drivers/vmx/vmx.go
@@ -492,8 +492,8 @@ func (d *Driver) Status(hwaddr string) string {
 	return drivers.StatusNone
 }
 
-func (d *Driver) Snapshot(hwaddr string, full bool) error {
-	return fmt.Errorf("VMX: Snapshot not implemented")
+func (d *Driver) Snapshot(hwaddr string, full bool) (string, error) {
+	return "", fmt.Errorf("VMX: Snapshot not implemented")
 }
 
 func (d *Driver) Deallocate(hwaddr string) error {

--- a/lib/fish/application.go
+++ b/lib/fish/application.go
@@ -75,27 +75,28 @@ func (f *Fish) ApplicationIsAllocated(app_id int64) (err error) {
 	return nil
 }
 
-func (f *Fish) ApplicationSnapshot(app *types.Application, full bool) error {
+func (f *Fish) ApplicationSnapshot(app *types.Application, full bool) (string, error) {
 	// Get application label to choose the right driver
 	label, err := f.LabelGet(app.LabelID)
 	if err != nil {
-		return fmt.Errorf("Fish: Label not found: %w", err)
+		return "", fmt.Errorf("Fish: Label not found: %w", err)
 	}
 
 	driver := f.DriverGet(label.Driver)
 	if driver == nil {
-		return fmt.Errorf("Fish: Driver not available: %s", label.Driver)
+		return "", fmt.Errorf("Fish: Driver not available: %s", label.Driver)
 	}
 
 	// Get resource to locate hwaddr
 	res, err := f.ResourceGetByApplication(app.ID)
 	if err != nil {
-		return fmt.Errorf("Fish: Resource not found: %w", err)
+		return "", fmt.Errorf("Fish: Resource not found: %w", err)
 	}
 
-	if driver.Snapshot(res.HwAddr, full) != nil {
-		return fmt.Errorf("Fish: Unable to create snapshot: %w", err)
+	out, err := driver.Snapshot(res.HwAddr, full)
+	if err != nil {
+		return "", fmt.Errorf("Fish: Unable to create snapshot: %w", err)
 	}
 
-	return nil
+	return out, nil
 }

--- a/lib/openapi/api/api_v1.go
+++ b/lib/openapi/api/api_v1.go
@@ -283,11 +283,12 @@ func (e *Processor) ApplicationSnapshotGet(c echo.Context, id int64, params type
 	// TODO: not working correctly in cluster in case not all the nodes supports the
 	// driver - need to rewrite in cluster way as Resource Tasks.
 	full := params.Full != nil && *params.Full
-	if err = e.fish.ApplicationSnapshot(app, full); err != nil {
+	out, err := e.fish.ApplicationSnapshot(app, full)
+	if err != nil {
 		c.JSON(http.StatusNotFound, H{"message": fmt.Sprintf("Error during creating Application snapshot: %v", err)})
 	}
 
-	return c.JSON(http.StatusOK, H{})
+	return c.JSON(http.StatusOK, H{"data": out})
 }
 
 func (e *Processor) ApplicationDeallocateGet(c echo.Context, id int64) error {


### PR DESCRIPTION
Found that it's actually dangerous to not filter AMI and snapshots by completion - in case snapshot was just taken it will be the first in the list, but still pending so all the requests for the resource uses such snapshot will fail until it will be prepared.

Also added the way to tell the snapshot api user some info about the taken snapshots - just in case he would like to find them later.

## Related Issue

fixes: #3 

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

