### PR TITLE
Fixed API security issue with potential SQL injection in filter

### DIFF
--- a/_build.sh
+++ b/_build.sh
@@ -19,11 +19,17 @@ echo "ROOT DIR: ${root_dir}"
 cd "${root_dir}"
 
 
-gopath=$(go env GOPATH)
-
 echo "--- GENERATE CODE FOR AQUARIUM-FISH ---"
+# Install oapi-codegen if it's not available or version is not the same with go.mod
+gopath=$(go env GOPATH)
+req_ver=$(grep -F 'github.com/deepmap/oapi-codegen' go.mod | cut -d' ' -f 2)
+curr_ver="$(PATH="$gopath/bin:$PATH" oapi-codegen --version 2>/dev/null | tail -1 || true)"
+if [ "$curr_ver" != "$req_ver" ]; then
+    go install "github.com/deepmap/oapi-codegen/cmd/oapi-codegen@$req_ver"
+fi
+# Cleanup the old generated files & run the generation
 find ./lib -name '*.gen.go' -delete
-go generate -v ./lib/...
+PATH="$gopath/bin:$PATH" go generate -v ./lib/...
 
 # Doing check after generation because generated sources requires additional modules
 ./check.sh

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/labstack/echo/v4 v4.9.1
 	github.com/mostlygeek/arp v0.0.0-20170424181311-541a2129847a
 	github.com/pkg/errors v0.9.1
+	github.com/rqlite/sql v0.0.0-20221103124402-8f9ff0ceb8f0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.0.0
 	github.com/steinfletcher/apitest v1.5.14

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrKU=
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
@@ -176,6 +177,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rqlite/sql v0.0.0-20221103124402-8f9ff0ceb8f0 h1:C8DZB5okjhCSd7zvkOM+zxGz7S6ulUFIL34bpkqFk+0=
+github.com/rqlite/sql v0.0.0-20221103124402-8f9ff0ceb8f0/go.mod h1:ib9zVtNgRKiGuoMyUqqL5aNpk+r+++YlyiVIkclVqPg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/lib/fish/application.go
+++ b/lib/fish/application.go
@@ -14,14 +14,22 @@ package fish
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) ApplicationFind(filter *string) (as []types.Application, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received", err)
+			// We do not fail here because we should not give attacker more information
+			return as, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&as).Error
 	return as, err

--- a/lib/fish/label.go
+++ b/lib/fish/label.go
@@ -14,14 +14,22 @@ package fish
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) LabelFind(filter *string) (labels []types.Label, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return labels, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&labels).Error
 	return labels, err

--- a/lib/fish/location.go
+++ b/lib/fish/location.go
@@ -14,14 +14,22 @@ package fish
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) LocationFind(filter *string) (ls []types.Location, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return ls, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&ls).Error
 	return ls, err

--- a/lib/fish/node.go
+++ b/lib/fish/node.go
@@ -21,12 +21,19 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) NodeFind(filter *string) (ns []types.Node, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return ns, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&ns).Error
 	return ns, err

--- a/lib/fish/resource.go
+++ b/lib/fish/resource.go
@@ -22,12 +22,19 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) ResourceFind(filter *string) (rs []types.Resource, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return rs, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&rs).Error
 	return rs, err

--- a/lib/fish/servicemapping.go
+++ b/lib/fish/servicemapping.go
@@ -14,14 +14,22 @@ package fish
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) ServiceMappingFind(filter *string) (sms []types.ServiceMapping, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return sms, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&sms).Error
 	return sms, err

--- a/lib/fish/user.go
+++ b/lib/fish/user.go
@@ -18,12 +18,19 @@ import (
 
 	"github.com/adobe/aquarium-fish/lib/crypt"
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) UserFind(filter *string) (us []types.User, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return us, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&us).Error
 	return us, err

--- a/lib/fish/vote.go
+++ b/lib/fish/vote.go
@@ -13,15 +13,23 @@
 package fish
 
 import (
+	"log"
 	"math/rand"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
 )
 
 func (f *Fish) VoteFind(filter *string) (vs []types.Vote, err error) {
 	db := f.db
 	if filter != nil {
-		db = db.Where(*filter)
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received:", err)
+			// We do not fail here because we should not give attacker more information
+			return vs, nil
+		}
+		db = db.Where(secured_filter)
 	}
 	err = db.Find(&vs).Error
 	return vs, err

--- a/lib/openapi/api/api_v1.go
+++ b/lib/openapi/api/api_v1.go
@@ -37,6 +37,8 @@ func NewV1Router(e *echo.Echo, fish *fish.Fish) {
 	router.Use(
 		// Regular basic auth
 		echomw.BasicAuth(proc.BasicAuth),
+		// Limiting body size for better security, as usual 64KB ought to be enough for anybody
+		echomw.BodyLimit("64KB"),
 	)
 	RegisterHandlers(router, proc)
 }

--- a/lib/openapi/openapi.go
+++ b/lib/openapi/openapi.go
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12.2 -config types.cfg.yaml ../../docs/openapi.yaml
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12.2 -config meta_v1.cfg.yaml ../../docs/openapi.yaml
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12.2 -config api_v1.cfg.yaml ../../docs/openapi.yaml
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12.2 -config spec.cfg.yaml ../../docs/openapi.yaml
+//go:generate oapi-codegen -config types.cfg.yaml ../../docs/openapi.yaml
+//go:generate oapi-codegen -config meta_v1.cfg.yaml ../../docs/openapi.yaml
+//go:generate oapi-codegen -config api_v1.cfg.yaml ../../docs/openapi.yaml
+//go:generate oapi-codegen -config spec.cfg.yaml ../../docs/openapi.yaml
 
 package openapi
 

--- a/lib/util/expression_sql_filter.go
+++ b/lib/util/expression_sql_filter.go
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package util
+
+import (
+	"strings"
+
+	"github.com/rqlite/sql"
+)
+
+// Ensures the where filter doesn't contain bad things (SQL injections) and returns a good one
+// could be used as Where() in gorm. It expects just an expression, so no other SQL keys will work
+// here. For example:
+// * `id=1 AND a in (1,2) ORDER BY i; DROP u;` will become just `"id" = 1 AND "a" IN (1, 2)`
+// * `DROP users` - will fail
+// * `id = 1 OR lol in (SELECT * FROM users)` - will fail
+func ExpressionSqlFilter(filter string) (string, error) {
+	reader := strings.NewReader(filter)
+	exp, err := sql.NewParser(reader).ParseExpr()
+	if err != nil {
+		return "", err
+	}
+	return exp.String(), nil
+}

--- a/lib/util/expression_sql_filter_test.go
+++ b/lib/util/expression_sql_filter_test.go
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	TEST_SQL_EXPRESSION_INJECTIONS = map[string]string{
+		``:                                   ``,
+		`1=1`:                                `1 = 1`,
+		`id = 3; DROP users`:                 `"id" = 3`,
+		`a IN (1,2) ORDER BY id; DROP users`: `"a" IN (1, 2)`,
+		// Fails
+		`SELECT * FROM users WHERE a = 1; DROP users`: ``, // Invalid expression
+		`a in (SELECT * FROM users)`:                  ``, // Subquery could be dangerous
+	}
+)
+
+func Test_expression_sql_filter_where_injections(t *testing.T) {
+	for sql, result := range TEST_SQL_EXPRESSION_INJECTIONS {
+		t.Run(fmt.Sprintf("Testing `%s`", sql), func(t *testing.T) {
+			out, err := ExpressionSqlFilter(sql)
+			if out != result {
+				t.Fatalf("ExpressionSQLFilter(`%s`) = `%s`, %v; want: `%s`", sql, out, err, result)
+			}
+		})
+	}
+}

--- a/lib/util/file_replace_token_test.go
+++ b/lib/util/file_replace_token_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestFileReplaceTokenSimpleProceed(t *testing.T) {
+func Test_file_replace_token_simple_proceed(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -46,7 +46,7 @@ func TestFileReplaceTokenSimpleProceed(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenSimpleSkipUppercaseSrc(t *testing.T) {
+func Test_file_replace_token_simple_skip_uppercase_src(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -72,7 +72,7 @@ func TestFileReplaceTokenSimpleSkipUppercaseSrc(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenSimpleSkipUppercaseToken(t *testing.T) {
+func Test_file_replace_token_simple_skip_uppercase_token(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -98,7 +98,7 @@ func TestFileReplaceTokenSimpleSkipUppercaseToken(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenAnycaseTokenProceed(t *testing.T) {
+func Test_file_replace_token_anycase_token_proceed(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -124,7 +124,7 @@ func TestFileReplaceTokenAnycaseTokenProceed(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenAnycaseSrcProceed(t *testing.T) {
+func Test_file_replace_token_anycase_src_proceed(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -150,7 +150,7 @@ func TestFileReplaceTokenAnycaseSrcProceed(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenAnycaseMultiple(t *testing.T) {
+func Test_file_replace_token_anycase_multiple(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -176,7 +176,7 @@ func TestFileReplaceTokenAnycaseMultiple(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenAdd(t *testing.T) {
+func Test_file_replace_token_add(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -201,7 +201,7 @@ func TestFileReplaceTokenAdd(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenDoNotAddIfReplaced(t *testing.T) {
+func Test_file_replace_token_do_not_add_if_replaced(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +
@@ -227,7 +227,7 @@ func TestFileReplaceTokenDoNotAddIfReplaced(t *testing.T) {
 	}
 }
 
-func TestFileReplaceTokenFullLine(t *testing.T) {
+func Test_file_replace_token_full_line(t *testing.T) {
 	tmp_file := path.Join(t.TempDir(), "test.txt")
 
 	in_data := []byte("" +

--- a/tests/label_find_filter_sql_injection_test.go
+++ b/tests/label_find_filter_sql_injection_test.go
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
+// Filters are using the user-defined SQL in find, so need to make sure there is no SQL injection
+// * Create a couple of labels
+// * A number of potential SQL injections
+// * A number of valid filter requests
+func Test_label_find_filter_sql_injection(t *testing.T) {
+	t.Parallel()
+	afi := RunAquariumFish(t, `---
+node_name: node-1
+node_location: test_loc
+
+api_address: 127.0.0.1:0
+
+drivers:
+  - name: test`)
+
+	t.Cleanup(func() {
+		afi.Cleanup()
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label1 types.Label
+	t.Run("Create Label 1", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label1", "version":1, "driver":"test", "definition": {"resources":{"cpu":1,"ram":2}}}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label1)
+
+		if label1.UID == uuid.Nil {
+			t.Fatalf("Label 1 UID is incorrect: %v", label1.UID)
+		}
+	})
+
+	var label2 types.Label
+	t.Run("Create Label 2", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label2", "version":1, "driver":"test", "definition": {"resources":{"cpu":1,"ram":2}}}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label2)
+
+		if label2.UID == uuid.Nil {
+			t.Fatalf("Label 2 UID is incorrect: %v", label2.UID)
+		}
+	})
+
+	var labels []types.Label
+	t.Run("Find Label 1 with simple SQL injection", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `name = '`+label1.Name+`'; DROP label`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 1 {
+			t.Fatalf("Label 1 not found: %q", labels)
+		}
+		if labels[0].UID != label1.UID {
+			t.Fatalf("Label 1 UID is incorrect: %v != %v", labels[0].UID, label1.UID)
+		}
+	})
+
+	t.Run("Find no labels with subquery SQL injection", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `name IN (DROP label)`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 0 {
+			t.Fatalf("Labels weirdly found, but should not be: %q", labels)
+		}
+	})
+
+	t.Run("Find no labels with stupid SQL injection", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `DROP label`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 0 {
+			t.Fatalf("Labels weirdly found, but should not be: %q", labels)
+		}
+	})
+
+	t.Run("Find Label 1", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `name='`+label1.Name+`'`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 1 {
+			t.Fatalf("Label 1 not found: %q", labels)
+		}
+		if labels[0].UID != label1.UID {
+			t.Fatalf("Label 1 UID is incorrect: %v != %v", labels[0].UID, label1.UID)
+		}
+	})
+
+	t.Run("Find Label 2", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `name = '`+label2.Name+`'`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 1 {
+			t.Fatalf("Label 2 not found: %q", labels)
+		}
+		if labels[0].UID != label2.UID {
+			t.Fatalf("Label 2 UID is incorrect: %v != %v", labels[0].UID, label2.UID)
+		}
+	})
+
+	t.Run("Find all labels with LIKE", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `name LIKE 'test-label%'`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 2 {
+			t.Fatalf("Labels not found: %q", labels)
+		}
+	})
+
+	t.Run("Find all labels with IN", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/label/")).
+			Query("filter", `name IN ('`+label1.Name+`', '`+label2.Name+`')`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&labels)
+
+		if len(labels) != 2 {
+			t.Fatalf("Labels not found: %q", labels)
+		}
+	})
+}


### PR DESCRIPTION
This security fix closes the hole in API during get requests that tries to find items in DB using user-provided SQL-queries. The fix uses SQL parser to cut out the expression and not to allow any other statements to get through. So the interface was not changed and just improved from security perspective.

In addition it removes version duplication in code generation (openapi) & uses cached oapi-codegen binary to allow to separate dependency loading & build and improve speed of code gen.

## Related Issue

fixes: #33 

## How Has This Been Tested?

Automatically through unit and integration tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.