### PR TITLE
Reimplemented snapshot mechanims & redesigned drivers & resource interfaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Main workflow
+name: CI
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,12 @@ jobs:
       run: ./build-linux.sh
 
     - name: Test
-      run: FISH_PATH=$PWD/aquarium-fish.linux_amd64 go test -v -failfast -parallel 4 -count=1 ./tests/...
+      run: |
+        go install github.com/jstemmer/go-junit-report/v2@latest
+        FISH_PATH=$PWD/aquarium-fish.linux_amd64 go test -failfast -parallel 4 -count=1 ./tests/... | go-junit-report -iocopy -set-exit-code -out report.xml
+
+    - name: Test Summary
+      uses: test-summary/action@v1
+      if: always()
+      with:
+        paths: report.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,13 +36,19 @@ jobs:
     - name: Build
       run: ./build-linux.sh
 
+    - name: Upload binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: binaries
+        path: aquarium-fish.*
+
     - name: Test
       run: |
         go install github.com/jstemmer/go-junit-report/v2@latest
-        FISH_PATH=$PWD/aquarium-fish.linux_amd64 go test -failfast -parallel 4 -count=1 ./tests/... | go-junit-report -iocopy -set-exit-code -out report.xml
+        FISH_PATH=$PWD/aquarium-fish.linux_amd64 go test -v -failfast -parallel 4 -count=1 ./tests/... 2>&1 | go-junit-report -iocopy -set-exit-code -out report.xml
 
     - name: Test Summary
-      uses: test-summary/action@v1
+      uses: test-summary/action@v2
       if: always()
       with:
         paths: report.xml

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ There is a number of ways to communicate with the Fish cluster, and the most imp
 You can use `curl`, for example, to do that:
 ```
 $ curl -u "admin:YOUR_TOKEN" -X GET 127.0.0.1:8001/api/v1/label/
-{"message": "Cluster resources list", "data": [{...}, ...]}
+{...json data...}
 ```
 
 The current API could be found in OpenAPI format here:
  * When the Fish app is running locally: https://0.0.0.0:8001/api/
  * YAML specification: https://github.com/adobe/aquarium-fish/blob/main/docs/openapi.yaml
 
-Also check `example` and `tests` folder to get more info about the API usage.
+Also check `example` and `tests` folder to get more info about the typical API usage.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Aquarium Fish](https://github.com/adobe/aquarium-fish)
 
-[![CI](https://github.com/adobe/aquarium-fish/actions/workflows/main.yml/badge.svg)](https://github.com/adobe/aquarium-fish/actions/workflows/main.yml)
+[![CI](https://github.com/adobe/aquarium-fish/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/adobe/aquarium-fish/actions/workflows/main.yml)
 
 Main part of the [Aquarium](https://github.com/adobe/aquarium-fish/wiki/Aquarium) distributed p2p
 system to manage resources. Primarily was developed to manage the dynamic Jenkins CI agents in

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -50,7 +50,7 @@ paths:
         - basic_auth: []
     post:
       summary: Create new User
-      description: Creates & return the created User
+      description: Creates & return the created User, it will generate password if not provided
       operationId: UserCreatePost
       tags:
         - User
@@ -60,14 +60,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/User'
+              $ref: '#/components/schemas/UserAPIPassword'
       responses:
         '200':
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserAPIPassword'
         '400':
           description: Bad request
         '401':
@@ -453,11 +453,11 @@ paths:
       security:
         - basic_auth: []
 
-  /api/v1/application/{uid}/snapshot:
+  /api/v1/application/{uid}/task/:
     get:
-      summary: Triggers Application snapshot
-      description: Creates the Application's Resource snapshot
-      operationId: ApplicationSnapshotGet
+      summary: Get list of the ApplicationTasks
+      description: Returns the list of the Application tasks
+      operationId: ApplicationTaskListGet
       tags:
         - Application
       parameters:
@@ -468,24 +468,58 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: full
+        - name: filter
           in: query
-          description: >
-            Specify in order to include image changes (and memory of VM if posible) into the
-            snapshot. Most of the drivers can at least save the disks state. In better some we can
-            have the entire started VM with memory as it was in time of snapshot taking.
+          description: SQL `WHERE` filter for the object data
           required: false
           schema:
-            type: boolean
+            type: string
       responses:
         '200':
           description: Successful operation
-        '400':
-          description: Bad parameter or conditions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApplicationTask'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Application not found
+      security:
+        - basic_auth: []
+    post:
+      summary: Create new ApplicationTask
+      description: Creates the ApplicationTask for Application
+      operationId: ApplicationTaskCreatePost
+      tags:
+        - Application
+      parameters:
+        - name: uid
+          in: path
+          description: UID of the Application
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationTask'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationTask'
+        '400':
+          description: Bad request
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
       security:
         - basic_auth: []
 
@@ -927,15 +961,65 @@ components:
           type: string
           description: Additional information for the state
 
+    ApplicationTaskUID:
+      type: string
+      format: uuid
+      x-oapi-codegen-extra-tags:
+        gorm: primaryKey
+    ApplicationTask:
+      type: object
+      description: >
+        Is needed to execute some sort of async action on the Application. For example snapshot
+        operation, because the request could get from anywhere. Usually app tasks are not a part of
+        standard Application state graph and could be not executed if the resource is destroyed.
+
+        Results are filled by the executor of the task and really depends on what kind of operation
+        is executed and really depends on the driver - it could support the task or not.
+
+        It could be created by any Node but updated by the one which won the Application execution.
+      required:
+        - UID
+        - created_at
+        - updated_at
+        - application_UID
+        - task
+        - options
+        - result
+      properties:
+        UID:
+          $ref: '#/components/schemas/ApplicationTaskUID'
+          x-oapi-codegen-extra-tags:
+            gorm: primaryKey
+        created_at:
+          x-go-type: time.Time
+        updated_at:
+          x-go-type: time.Time
+        application_UID:
+          # TODO: in OAPI v3.1.0 siblings: $ref: '#/components/schemas/ApplicationUID'
+          type: string
+          format: uuid
+        task:
+          type: string
+          description: Identifier of the task
+        options:
+          x-go-type: util.UnparsedJson
+          description: JSON object with additional options
+        result:
+          x-go-type: util.UnparsedJson
+          description: JSON object with the results of task execution
+
     UserName:
       type: string
       x-oapi-codegen-extra-tags:
         gorm: primaryKey
+
     User:
       type: object
       description: >
         Contains limits and hash to login, name is unique, `admin` created during the first cluster
         start and prints it to stderr.
+
+        Could be created by any node and updated by any node.
       required:
         - name
         - created_at
@@ -954,6 +1038,30 @@ components:
           x-go-type: crypt.Hash
           x-oapi-codegen-extra-tags:
             gorm: embedded
+
+    UserAPIPassword:
+      type: object
+      description: >
+        Purely API-only special user object to use during User create operation - it allows to set
+        the required user password or receive the automatically generated one.
+      required:
+        - name
+        - created_at
+        - updated_at
+        - password
+        - hash
+      properties:
+        name:
+          $ref: '#/components/schemas/UserName'
+        created_at:
+          x-go-type: time.Time
+        updated_at:
+          x-go-type: time.Time
+        password:
+          type: string
+          description: Clear-text password to set for new user or to get the autogenerated one
+        hash:
+          x-go-type: crypt.Hash
 
     LabelUID:
       type: string
@@ -1042,6 +1150,8 @@ components:
       description: >
         Each node need to report it's status and ensure there is no duplications and to perform the
         cluster worker election process properly.
+
+        Could be created by the node itself and updated by the same node.
       required:
         - UID
         - created_at
@@ -1117,6 +1227,8 @@ components:
         Active resource definition to be able to properly restore the state during the cluster node
         restart. Also contains additional info about the resource, for example user requested
         metadata, which is available for the resource through the `Meta API`.
+
+        Could be created and updated only by the node which won the Application execution.
       required:
         - UID
         - created_at

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -924,6 +924,16 @@ components:
       format: uuid
       x-oapi-codegen-extra-tags:
         gorm: primaryKey
+    ApplicationStatus:
+      type: string
+      enum:
+        - NEW          # The Application just created (active)
+        - ELECTED      # Node is elected during the voting process (active)
+        - ALLOCATED    # The Resource is allocated and starting up (active)
+        - DEALLOCATE   # User requested the Application deallocate (not active)
+        - RECALLED     # User requested the Application deallocate, but it was not allocated (not active)
+        - DEALLOCATED  # The Resource is deallocated (not active)
+        - ERROR        # The error happened (not active)
     ApplicationState:
       type: object
       description: >
@@ -948,15 +958,7 @@ components:
           type: string
           format: uuid
         status:
-          type: string
-          enum:
-            - NEW          # The Application just created (active)
-            - ELECTED      # Node is elected during the voting process (active)
-            - ALLOCATED    # The Resource is allocated and starting up (active)
-            - DEALLOCATE   # User requested the Application deallocate (not active)
-            - RECALLED     # User requested the Application deallocate, but it was not allocated (not active)
-            - DEALLOCATED  # The Resource is deallocated (not active)
-            - ERROR        # The error happened (not active)
+          $ref: '#/components/schemas/ApplicationStatus'
         description:
           type: string
           description: Additional information for the state
@@ -983,6 +985,7 @@ components:
         - updated_at
         - application_UID
         - task
+        - when
         - options
         - result
       properties:
@@ -1001,6 +1004,11 @@ components:
         task:
           type: string
           description: Identifier of the task
+        when:
+          $ref: '#/components/schemas/ApplicationStatus'
+          description: |
+            Used to specify when the task should be executed, right now only ALLOCATED, DEALLOCATE
+            and RECALLED (when app is already here) are supported.
         options:
           x-go-type: util.UnparsedJson
           description: JSON object with additional options
@@ -1235,6 +1243,7 @@ components:
         - updated_at
         - application_UID
         - node_UID
+        - identifier
         - ip_addr
         - hw_addr
         - metadata
@@ -1255,15 +1264,25 @@ components:
           # TODO: in OAPI v3.1.0 siblings: $ref: '#/components/schemas/NodeUID'
           type: string
           format: uuid
+        identifier:
+          type: string
+          description: |
+            Unique for driver identifier of the resource which can be used to find it later.
         ip_addr:
           type: string
-          description: Is a weak current network IP address of the resource, usually gathered based on the `HwAddr`.
+          description: >
+            Is a weak current network IP address of the resource, usually gathered based on the
+            `hw_addr`.
         hw_addr:
           type: string
-          description: MAC or any other type of network address which will allow to properly identify the node through network interaction.
+          description: >
+            MAC or any other type of network address which will allow to properly identify the node
+            through network interaction.
         metadata:
           x-go-type: util.UnparsedJson
-          description: Combined Application and Label metadata (in this order) to make it available through `Meta API` to the resource.
+          description: >
+            Combined Application and Label metadata (in this order) to make it available through
+            `Meta API` to the resource.
           example:
             JENKINS_URL: 'http://172.16.1.1:8085/'
             JENKINS_AGENT_SECRET: 03839eabcf945b1e780be8f9488d264c4c57bf388546da9a84588345555f29b0

--- a/lib/drivers/aws/driver.go
+++ b/lib/drivers/aws/driver.go
@@ -26,10 +26,12 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 
+	"github.com/adobe/aquarium-fish/lib/crypt"
 	"github.com/adobe/aquarium-fish/lib/drivers"
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
 	"github.com/adobe/aquarium-fish/lib/util"
 )
 
@@ -96,12 +98,12 @@ func (d *Driver) AvailableCapacity(node_usage drivers.Resources, definition stri
 		// terminated only after 24h which costs a pretty penny.
 		// Quotas for hosts are: "Running Dedicated mac1 Hosts" & "Running Dedicated mac2 Hosts"
 		p := ec2.NewDescribeHostsPaginator(conn_ec2, &ec2.DescribeHostsInput{
-			Filter: []types.Filter{
-				types.Filter{
+			Filter: []ec2_types.Filter{
+				ec2_types.Filter{
 					Name:   aws.String("instance-type"),
 					Values: []string{fmt.Sprintf("%s.metal", def.InstanceType)},
 				},
-				types.Filter{
+				ec2_types.Filter{
 					Name:   aws.String("state"),
 					Values: []string{"available"},
 				},
@@ -199,11 +201,15 @@ func (d *Driver) AvailableCapacity(node_usage drivers.Resources, definition stri
  * It selects the AMI and run instance
  * Uses metadata to fill EC2 instance userdata
  */
-func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (string, string, error) {
+func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (*types.Resource, error) {
 	var def Definition
 	if err := def.Apply(definition); err != nil {
-		return "", "", fmt.Errorf("AWS: Unable to apply definition: %v", err)
+		return nil, fmt.Errorf("AWS: Unable to apply definition: %v", err)
 	}
+
+	// Generate fish name
+	buf := crypt.RandBytes(6)
+	i_name := fmt.Sprintf("fish-%02x%02x%02x%02x%02x%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5])
 
 	conn := d.newEC2Conn()
 
@@ -211,22 +217,22 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 	vm_network := def.Resources.Network
 	var err error
 	if vm_network, _, err = d.getSubnetId(conn, vm_network); err != nil {
-		return "", "", fmt.Errorf("AWS: Unable to get subnet: %v", err)
+		return nil, fmt.Errorf("AWS: Unable to get subnet: %v", err)
 	}
-	log.Println("AWS: Selected subnet:", vm_network)
+	log.Println("AWS: Selected subnet:", vm_network, i_name)
 
 	vm_image := def.Image
 	if vm_image, err = d.getImageId(conn, vm_image); err != nil {
-		return "", "", fmt.Errorf("AWS: Unable to get image: %v", err)
+		return nil, fmt.Errorf("AWS: Unable to get image: %v", err)
 	}
-	log.Println("AWS: Selected image:", vm_image)
+	log.Println("AWS: Selected image:", vm_image, i_name)
 
 	// Prepare Instance request information
 	input := &ec2.RunInstancesInput{
 		ImageId:      aws.String(vm_image),
-		InstanceType: types.InstanceType(def.InstanceType),
+		InstanceType: ec2_types.InstanceType(def.InstanceType),
 
-		NetworkInterfaces: []types.InstanceNetworkInterfaceSpecification{
+		NetworkInterfaces: []ec2_types.InstanceNetworkInterfaceSpecification{
 			{
 				AssociatePublicIpAddress: aws.Bool(false),
 				DeleteOnTermination:      aws.Bool(true),
@@ -243,7 +249,7 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 		// Set UserData field
 		userdata, err := util.SerializeMetadata(def.UserDataFormat, def.UserDataPrefix, metadata)
 		if err != nil {
-			return "", "", fmt.Errorf("AWS: Unable to serialize metadata to userdata: %v", err)
+			return nil, fmt.Errorf("AWS: Unable to serialize metadata to userdata: %v", err)
 		}
 		input.UserData = aws.String(base64.StdEncoding.EncodeToString([]byte(userdata)))
 	}
@@ -251,9 +257,9 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 	if def.SecurityGroup != "" {
 		vm_secgroup := def.SecurityGroup
 		if vm_secgroup, err = d.getSecGroupId(conn, vm_secgroup); err != nil {
-			return "", "", fmt.Errorf("AWS: Unable to get security group: %v", err)
+			return nil, fmt.Errorf("AWS: Unable to get security group: %v", err)
 		}
-		log.Println("AWS: Selected security group:", vm_secgroup)
+		log.Println("AWS: Selected security group:", vm_secgroup, i_name)
 		input.NetworkInterfaces[0].Groups = []string{vm_secgroup}
 	}
 
@@ -267,49 +273,53 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 			tags_in[k] = v
 		}
 
-		tags_out := []types.Tag{}
+		tags_out := []ec2_types.Tag{}
 		for k, v := range tags_in {
-			tags_out = append(tags_out, types.Tag{
+			tags_out = append(tags_out, ec2_types.Tag{
 				Key:   aws.String(k),
 				Value: aws.String(v),
 			})
 		}
+		// Apply name for the instance
+		tags_out = append(tags_out, ec2_types.Tag{
+			Key:   aws.String("Name"),
+			Value: aws.String(i_name),
+		})
 
-		input.TagSpecifications = []types.TagSpecification{
+		input.TagSpecifications = []ec2_types.TagSpecification{
 			{
-				ResourceType: types.ResourceTypeInstance,
+				ResourceType: ec2_types.ResourceTypeInstance,
 				Tags:         tags_out,
 			},
 		}
-
 	}
 
 	// Prepare the device mapping
 	if len(def.Resources.Disks) > 0 {
 		for name, disk := range def.Resources.Disks {
-			mapping := types.BlockDeviceMapping{
+			mapping := ec2_types.BlockDeviceMapping{
 				DeviceName: aws.String(name),
-				Ebs: &types.EbsBlockDevice{
+				Ebs: &ec2_types.EbsBlockDevice{
 					DeleteOnTermination: aws.Bool(true),
-					VolumeType:          types.VolumeTypeGp3,
+					VolumeType:          ec2_types.VolumeTypeGp3,
 				},
 			}
 			if disk.Type != "" {
 				type_data := strings.Split(disk.Type, ":")
 				if len(type_data) > 0 && type_data[0] != "" {
-					mapping.Ebs.VolumeType = types.VolumeType(type_data[0])
+					mapping.Ebs.VolumeType = ec2_types.VolumeType(type_data[0])
 				}
 				if len(type_data) > 1 && type_data[1] != "" {
 					val, err := strconv.ParseInt(type_data[1], 10, 32)
 					if err != nil {
-						return "", "", fmt.Errorf("AWS: Unable to parse EBS IOPS int32 from '%s': %v", type_data[1], err)
+						return nil, fmt.Errorf("AWS: Unable to parse EBS IOPS int32 from '%s': %v", type_data[1], err)
 					}
 					mapping.Ebs.Iops = aws.Int32(int32(val))
 				}
 				if len(type_data) > 2 && type_data[2] != "" {
 					val, err := strconv.ParseInt(type_data[2], 10, 32)
 					if err != nil {
-						return "", "", fmt.Errorf("AWS: Unable to parse EBS Throughput int32 from '%s': %v", type_data[1], err)
+						return nil, fmt.Errorf("AWS: Unable to parse EBS Throughput int32 from '%s': %v", type_data[1], err)
 					}
 					mapping.Ebs.Throughput = aws.Int32(int32(val))
 				}
@@ -318,9 +328,9 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 				// Use snapshot as the disk source
 				vm_snapshot := disk.Clone
 				if vm_snapshot, err = d.getSnapshotId(conn, vm_snapshot); err != nil {
-					return "", "", fmt.Errorf("AWS: Unable to get snapshot: %v", err)
+					return nil, fmt.Errorf("AWS: Unable to get snapshot: %v", err)
 				}
-				log.Println("AWS: Selected snapshot:", vm_snapshot)
+				log.Println("AWS: Selected snapshot:", vm_snapshot, i_name)
 				mapping.Ebs.SnapshotId = aws.String(vm_snapshot)
 			} else {
 				// Just create a new disk
@@ -329,9 +339,9 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 					mapping.Ebs.Encrypted = aws.Bool(true)
 					key_id, err := d.getKeyId(def.EncryptKey)
 					if err != nil {
-						return "", "", fmt.Errorf("AWS: Unable to get encrypt key from KMS: %v", err)
+						return nil, fmt.Errorf("AWS: Unable to get encrypt key from KMS: %v", err)
 					}
-					log.Println("AWS: Selected encryption key:", key_id, "for disk:", name)
+					log.Println("AWS: Selected encryption key:", key_id, "for disk:", name, i_name)
 					mapping.Ebs.KmsKeyId = aws.String(key_id)
 				}
 			}
@@ -342,8 +352,8 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 	// Run the instance
 	result, err := conn.RunInstances(context.TODO(), input)
 	if err != nil {
-		log.Println("AWS: Unable to run instance", err)
-		return "", "", err
+		log.Println("AWS: Unable to run instance", err, i_name)
+		return nil, err
 	}
 
 	inst := &result.Instances[0]
@@ -368,19 +378,18 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 				inst = inst_tmp
 			}
 			if err != nil {
-				log.Println("AWS: Error during getting instance while waiting for BlockDeviceMappings:", err, *inst.InstanceId)
+				log.Println("AWS: Error during getting instance while waiting for BlockDeviceMappings:", err, i_name)
 			}
 		}
 		for _, bd := range inst.BlockDeviceMappings {
 			disk, ok := def.Resources.Disks[*bd.DeviceName]
-			log.Println("AWS: DEBUG: Processing volume:", *bd.DeviceName, disk)
 			if !ok || disk.Label == "" {
 				continue
 			}
 
 			tags_input := &ec2.CreateTagsInput{
 				Resources: []string{*bd.Ebs.VolumeId},
-				Tags:      []types.Tag{},
+				Tags:      []ec2_types.Tag{},
 			}
 
 			tag_vals := strings.Split(disk.Label, ",")
@@ -389,11 +398,10 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 				if len(key_val) < 2 {
 					key_val = append(key_val, "")
 				}
-				tags_input.Tags = append(tags_input.Tags, types.Tag{
+				tags_input.Tags = append(tags_input.Tags, ec2_types.Tag{
 					Key:   aws.String(key_val[0]),
 					Value: aws.String(key_val[1]),
 				})
-				log.Println("AWS: DEBUG: Creating tags for the volume:", *bd.Ebs.VolumeId, key_val[0], key_val[0])
 			}
 			if _, err := conn.CreateTags(context.TODO(), tags_input); err != nil {
 				// Do not fail hard here - the instance is already running
@@ -402,12 +410,16 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 		}
 	}
 
+	res := &types.Resource{}
+
 	// Wait for IP address to be assigned to the instance
 	timeout := 60
 	for {
 		if inst.PrivateIpAddress != nil {
-			log.Println("AWS: Allocate of instance completed:", *inst.InstanceId, *inst.PrivateIpAddress)
-			return *inst.InstanceId, *inst.PrivateIpAddress, nil
+			log.Println("AWS: Allocate of instance completed:", i_name, *inst.InstanceId, *inst.PrivateIpAddress)
+			res.Identifier = *inst.InstanceId
+			res.IpAddr = *inst.PrivateIpAddress
+			return res, nil
 		}
 
 		timeout -= 5
@@ -421,22 +433,27 @@ func (d *Driver) Allocate(definition string, metadata map[string]interface{}) (s
 			inst = inst_tmp
 		}
 		if err != nil {
-			log.Println("AWS: Error during getting instance while waiting for IP:", err, *inst.InstanceId)
+			log.Println("AWS: Error during getting instance while waiting for IP:", err, i_name, *inst.InstanceId)
 		}
 	}
 
-	return *inst.InstanceId, "", fmt.Errorf("AWS: Unable to locate the instance IP: %s", *inst.InstanceId)
+	res.Identifier = *inst.InstanceId
+	return res, fmt.Errorf("AWS: Unable to locate the instance IP: %s", *inst.InstanceId)
 }
 
-func (d *Driver) Status(inst_id string) string {
-	conn := d.newEC2Conn()
-	inst, err := d.getInstance(conn, inst_id)
-	// Potential issue here, it could be a big problem with unstable connection
-	if err != nil {
-		log.Println("AWS: Error during status check for", inst_id, "- it needs a rewrite", err)
+func (d *Driver) Status(res *types.Resource) string {
+	if res == nil || res.Identifier == "" {
+		log.Println("AWS: Invalid resource:", res)
 		return drivers.StatusNone
 	}
-	if inst != nil && inst.State.Name != types.InstanceStateNameTerminated {
+	conn := d.newEC2Conn()
+	inst, err := d.getInstance(conn, res.Identifier)
+	// Potential issue here, it could be a big problem with unstable connection
+	if err != nil {
+		log.Println("AWS: Error during status check for", res.Identifier, "- it needs a rewrite", err)
+		return drivers.StatusNone
+	}
+	if inst != nil && inst.State.Name != ec2_types.InstanceStateNameTerminated {
 		return drivers.StatusAllocated
 	}
 	return drivers.StatusNone
@@ -462,22 +479,25 @@ func (d *Driver) GetTask(name, options string) drivers.ResourceDriverTask {
 	return t
 }
 
-func (d *Driver) Deallocate(inst_id string) error {
+func (d *Driver) Deallocate(res *types.Resource) error {
+	if res == nil || res.Identifier == "" {
+		return fmt.Errorf("AWS: Invalid resource: %v", res)
+	}
 	conn := d.newEC2Conn()
 
 	input := &ec2.TerminateInstancesInput{
-		InstanceIds: []string{inst_id},
+		InstanceIds: []string{res.Identifier},
 	}
 
 	result, err := conn.TerminateInstances(context.TODO(), input)
 	if err != nil {
-		return fmt.Errorf("AWS: Error during termianting the instance %s: %s", inst_id, err)
+		return fmt.Errorf("AWS: Error during termianting the instance %s: %s", res.Identifier, err)
 	}
-	if *result.TerminatingInstances[0].InstanceId != inst_id {
-		return fmt.Errorf("AWS: Wrong instance id result %s during terminating of %s", *result.TerminatingInstances[0].InstanceId, inst_id)
+	if *result.TerminatingInstances[0].InstanceId != res.Identifier {
+		return fmt.Errorf("AWS: Wrong instance id result %s during terminating of %s", *result.TerminatingInstances[0].InstanceId, res.Identifier)
 	}
 
-	log.Println("AWS: Deallocate of Instance", inst_id, "completed:", result.TerminatingInstances[0].CurrentState.Name)
+	log.Println("AWS: Deallocate of Instance", res.Identifier, "completed:", result.TerminatingInstances[0].CurrentState.Name)
 
 	return nil
 }

--- a/lib/drivers/aws/tasks.go
+++ b/lib/drivers/aws/tasks.go
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/adobe/aquarium-fish/lib/drivers"
+)
+
+type TaskSnapshot struct {
+	driver *Driver `json:"-"`
+
+	Full bool `json:"full"` // Make full (all disks including OS image), or just the additional disks snapshot
+}
+
+func (t *TaskSnapshot) Name() string {
+	return "snapshot"
+}
+
+func (t *TaskSnapshot) Clone() drivers.ResourceDriverTask {
+	n := *t
+	return &n
+}
+
+func (t *TaskSnapshot) Execute(inst_id string) (result []byte, err error) {
+	conn := t.driver.newEC2Conn()
+
+	input := &ec2.CreateSnapshotsInput{
+		InstanceSpecification: &types.InstanceSpecification{
+			ExcludeBootVolume: aws.Bool(!t.Full),
+			InstanceId:        &inst_id,
+		},
+		Description:        aws.String("Created by AquariumFish"),
+		CopyTagsFromSource: types.CopyTagsFromSourceVolume,
+		TagSpecifications: []types.TagSpecification{{
+			ResourceType: "snapshot",
+			Tags: []types.Tag{{
+				Key:   aws.String("InstanceId"),
+				Value: aws.String(inst_id),
+			}},
+		}},
+	}
+
+	resp, err := conn.CreateSnapshots(context.TODO(), input)
+	if err != nil {
+		return []byte{}, fmt.Errorf("AWS: Unable to create snapshots for instance %s: %v", inst_id, err)
+	}
+	if len(resp.Snapshots) < 1 {
+		return []byte{}, fmt.Errorf("AWS: No snapshots was created for instance %s", inst_id)
+	}
+
+	snapshots := []string{}
+	for _, r := range resp.Snapshots {
+		snapshots = append(snapshots, *r.SnapshotId)
+	}
+	log.Println("AWS: Created snapshots for instance", inst_id, ":", strings.Join(snapshots, ", "))
+
+	return json.Marshal(map[string]any{"snapshots": snapshots})
+}

--- a/lib/drivers/aws/util.go
+++ b/lib/drivers/aws/util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 )
 
-func (d *Driver) newConn() *ec2.Client {
+func (d *Driver) newEC2Conn() *ec2.Client {
 	return ec2.NewFromConfig(aws.Config{
 		Region: d.cfg.Region,
 		Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {

--- a/lib/drivers/docker/util.go
+++ b/lib/drivers/docker/util.go
@@ -264,10 +264,10 @@ func (d *Driver) loadImages(def *Definition) (string, error) {
 	return target_out, nil
 }
 
-// Receives the container ID out of the hwaddr unique id
-func (d *Driver) getAllocatedContainer(hwaddr string) string {
+// Receives the container ID out of the container name
+func (d *Driver) getAllocatedContainerId(c_name string) string {
 	// Probably it's better to store the current list in the memory
-	stdout, _, err := runAndLog(5*time.Second, d.cfg.DockerPath, "ps", "-a", "-q", "--filter", "name="+d.getContainerName(hwaddr))
+	stdout, _, err := runAndLog(5*time.Second, d.cfg.DockerPath, "ps", "-a", "-q", "--filter", "name="+c_name)
 	if err != nil {
 		return ""
 	}

--- a/lib/drivers/driver.go
+++ b/lib/drivers/driver.go
@@ -56,11 +56,10 @@ type ResourceDriver interface {
 	// Get the status of the resource with given hw address
 	Status(hwaddr string) string
 
-	// Makes environment snapshot of the resource with given hw address
-	// -> hwaddr - driver identifier of the resource
-	// -> full - will try it's best to make the complete snapshot of the environment, else just non-image data (attached disks)
-	// <- info - where to find the snapshots
-	Snapshot(hwaddr string, full bool) (info string, err error)
+	// Get task struct with implementation to execute it later
+	// -> task - identifier of the task operation
+	// -> options - additional config options for the task
+	GetTask(task, options string) ResourceDriverTask
 
 	// Deallocate resource with provided hw addr
 	// -> hwaddr - driver identifier of the resource

--- a/lib/drivers/driver.go
+++ b/lib/drivers/driver.go
@@ -12,6 +12,10 @@
 
 package drivers
 
+import (
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
 const (
 	StatusNone      = "NONE"
 	StatusAllocated = "ALLOCATED"
@@ -49,12 +53,12 @@ type ResourceDriver interface {
 	// Allocate the resource by definition and returns hw address
 	// -> definition - describes the driver options to allocate the required resource
 	// -> metadata - user metadata to use during resource allocation
-	// <- hwaddr - mandatory, needed to identify the resource. If it's a MAC address - it is used to auth in Meta API
-	// <- ipaddr - optional, if driver can provide the assigned IP address of the instance
-	Allocate(definition string, metadata map[string]interface{}) (hwaddr, ipaddr string, err error)
+	// <- res - initial resource information to store driver instance state
+	Allocate(definition string, metadata map[string]interface{}) (res *types.Resource, err error)
 
 	// Get the status of the resource with given hw address
-	Status(hwaddr string) string
+	// -> res - resource information with stored driver instance state
+	Status(res *types.Resource) string
 
 	// Get task struct with implementation to execute it later
 	// -> task - identifier of the task operation
@@ -62,6 +66,6 @@ type ResourceDriver interface {
 	GetTask(task, options string) ResourceDriverTask
 
 	// Deallocate resource with provided hw addr
-	// -> hwaddr - driver identifier of the resource
-	Deallocate(hwaddr string) error
+	// -> res - resource information with stored driver instance state
+	Deallocate(res *types.Resource) error
 }

--- a/lib/drivers/task.go
+++ b/lib/drivers/task.go
@@ -12,6 +12,10 @@
 
 package drivers
 
+import (
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
 type ResourceDriverTask interface {
 	// Name of the task
 	Name() string
@@ -20,8 +24,10 @@ type ResourceDriverTask interface {
 	// Will return new not related to the original task structure
 	Clone() ResourceDriverTask
 
-	// Run the task operation over the instance
-	// -> inst_id - driver identifier of the resource
+	// Fish provides the task information about the operated items
+	SetInfo(task *types.ApplicationTask, res *types.Resource)
+
+	// Run the task operation
 	// <- result - json data with results of operation
-	Execute(inst_id string) (result []byte, err error)
+	Execute() (result []byte, err error)
 }

--- a/lib/drivers/task.go
+++ b/lib/drivers/task.go
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package drivers
+
+type ResourceDriverTask interface {
+	// Name of the task
+	Name() string
+
+	// Copy the existing task structure
+	// Will return new not related to the original task structure
+	Clone() ResourceDriverTask
+
+	// Run the task operation over the instance
+	// -> inst_id - driver identifier of the resource
+	// <- result - json data with results of operation
+	Execute(inst_id string) (result []byte, err error)
+}

--- a/lib/drivers/test/config.go
+++ b/lib/drivers/test/config.go
@@ -42,9 +42,9 @@ func (c *Config) Apply(config []byte) error {
 		}
 	}
 
-	return RandomFail("ConfigApply", c.FailConfigApply)
+	return randomFail("ConfigApply", c.FailConfigApply)
 }
 
 func (c *Config) Validate() (err error) {
-	return RandomFail("ConfigValidate", c.FailConfigValidate)
+	return randomFail("ConfigValidate", c.FailConfigValidate)
 }

--- a/lib/drivers/test/definition.go
+++ b/lib/drivers/test/definition.go
@@ -39,7 +39,7 @@ func (d *Definition) Apply(definition string) error {
 		return err
 	}
 
-	return RandomFail("DefinitionApply", d.FailDefinitionApply)
+	return randomFail("DefinitionApply", d.FailDefinitionApply)
 }
 
 func (d *Definition) Validate() error {
@@ -48,5 +48,5 @@ func (d *Definition) Validate() error {
 		return fmt.Errorf("TEST: Resources validation failed: %s", err)
 	}
 
-	return RandomFail("DefinitionValidate", d.FailDefinitionValidate)
+	return randomFail("DefinitionValidate", d.FailDefinitionValidate)
 }

--- a/lib/drivers/test/tasks.go
+++ b/lib/drivers/test/tasks.go
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/adobe/aquarium-fish/lib/drivers"
+)
+
+type TaskSnapshot struct {
+	driver *Driver `json:"-"`
+
+	Full bool `json:"full"` // Make full (all disks including OS image), or just the additional disks snapshot
+}
+
+func (t *TaskSnapshot) Name() string {
+	return "snapshot"
+}
+
+func (t *TaskSnapshot) Clone() drivers.ResourceDriverTask {
+	n := *t
+	return &n
+}
+
+func (t *TaskSnapshot) Execute(res_id string) (result []byte, err error) {
+	if err := randomFail(fmt.Sprintf("Snapshot %s", res_id), t.driver.cfg.FailSnapshot); err != nil {
+		log.Printf("TEST: RandomFail: %v\n", err)
+		return []byte{}, err
+	}
+
+	t.driver.resources_lock.Lock()
+	defer t.driver.resources_lock.Unlock()
+
+	if _, ok := t.driver.resources[res_id]; !ok {
+		return []byte{}, fmt.Errorf("TEST: Unable to snapshot unavailable resource '%s'", res_id)
+	}
+
+	return []byte(`{"snapshots":["test-snapshot"]}`), nil
+}

--- a/lib/fish/application.go
+++ b/lib/fish/application.go
@@ -45,7 +45,7 @@ func (f *Fish) ApplicationCreate(a *types.Application) error {
 
 	// Create ApplicationState NEW too
 	f.ApplicationStateCreate(&types.ApplicationState{
-		ApplicationUID: a.UID, Status: types.ApplicationStateStatusNEW,
+		ApplicationUID: a.UID, Status: types.ApplicationStatusNEW,
 		Description: "Just created by Fish " + f.node.Name,
 	})
 	return err
@@ -71,7 +71,7 @@ func (f *Fish) ApplicationListGetStatusNew() (as []types.Application, err error)
 	err = f.db.Order("created_at").Where("UID in (?)",
 		f.db.Select("application_uid").Table("(?)",
 			f.db.Model(&types.ApplicationState{}).Select("application_uid, status, max(created_at)").Group("application_uid"),
-		).Where("Status = ?", types.ApplicationStateStatusNEW),
+		).Where("Status = ?", types.ApplicationStatusNEW),
 	).Find(&as).Error
 	return as, err
 }
@@ -80,7 +80,7 @@ func (f *Fish) ApplicationIsAllocated(app_uid types.ApplicationUID) (err error) 
 	state, err := f.ApplicationStateGetByApplication(app_uid)
 	if err != nil {
 		return err
-	} else if state.Status != types.ApplicationStateStatusALLOCATED {
+	} else if state.Status != types.ApplicationStatusALLOCATED {
 		return fmt.Errorf("Fish: The Application is not allocated")
 	}
 	return nil

--- a/lib/fish/application.go
+++ b/lib/fish/application.go
@@ -85,29 +85,3 @@ func (f *Fish) ApplicationIsAllocated(app_uid types.ApplicationUID) (err error) 
 	}
 	return nil
 }
-
-func (f *Fish) ApplicationSnapshot(app *types.Application, full bool) (string, error) {
-	// Get application label to choose the right driver
-	label, err := f.LabelGet(app.LabelUID)
-	if err != nil {
-		return "", fmt.Errorf("Fish: Label not found: %w", err)
-	}
-
-	driver := f.DriverGet(label.Driver)
-	if driver == nil {
-		return "", fmt.Errorf("Fish: Driver not available: %s", label.Driver)
-	}
-
-	// Get resource to locate hwaddr
-	res, err := f.ResourceGetByApplication(app.UID)
-	if err != nil {
-		return "", fmt.Errorf("Fish: Resource not found: %w", err)
-	}
-
-	out, err := driver.Snapshot(res.HwAddr, full)
-	if err != nil {
-		return "", fmt.Errorf("Fish: Unable to create snapshot: %w", err)
-	}
-
-	return out, nil
-}

--- a/lib/fish/application_state.go
+++ b/lib/fish/application_state.go
@@ -50,17 +50,17 @@ func (f *Fish) ApplicationStateGetByApplication(app_uid types.ApplicationUID) (a
 }
 
 // Return false if Status in ERROR, DEALLOCATE or DEALLOCATED state
-func (f *Fish) ApplicationStateIsActive(status types.ApplicationStateStatus) bool {
-	if status == types.ApplicationStateStatusERROR {
+func (f *Fish) ApplicationStateIsActive(status types.ApplicationStatus) bool {
+	if status == types.ApplicationStatusERROR {
 		return false
 	}
-	if status == types.ApplicationStateStatusDEALLOCATE {
+	if status == types.ApplicationStatusDEALLOCATE {
 		return false
 	}
-	if status == types.ApplicationStateStatusRECALLED {
+	if status == types.ApplicationStatusRECALLED {
 		return false
 	}
-	if status == types.ApplicationStateStatusDEALLOCATED {
+	if status == types.ApplicationStatusDEALLOCATED {
 		return false
 	}
 	return true

--- a/lib/fish/application_task.go
+++ b/lib/fish/application_task.go
@@ -61,7 +61,7 @@ func (f *Fish) ApplicationTaskGet(uid types.ApplicationTaskUID) (at *types.Appli
 	return at, err
 }
 
-func (f *Fish) ApplicationTaskListByApplication(app_uid types.ApplicationUID) (at []types.ApplicationTask, err error) {
-	err = f.db.Where("application_uid = ?", app_uid).Order("created_at desc").Find(&at).Error
+func (f *Fish) ApplicationTaskListByApplicationAndWhen(app_uid types.ApplicationUID, when types.ApplicationStatus) (at []types.ApplicationTask, err error) {
+	err = f.db.Where(`application_uid = ? AND "when" = ?`, app_uid, when).Order("created_at desc").Find(&at).Error
 	return at, err
 }

--- a/lib/fish/application_task.go
+++ b/lib/fish/application_task.go
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package fish
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	"github.com/adobe/aquarium-fish/lib/util"
+)
+
+func (f *Fish) ApplicationTaskFindByApplication(uid types.ApplicationUID, filter *string) (at []types.ApplicationTask, err error) {
+	db := f.db.Where("application_uid = ?", uid)
+	if filter != nil {
+		secured_filter, err := util.ExpressionSqlFilter(*filter)
+		if err != nil {
+			log.Println("Fish: SECURITY: weird SQL filter received", err)
+			// We do not fail here because we should not give attacker more information
+			return at, nil
+		}
+		// Adding parentheses to be sure we're have `application_uid AND (filter)`
+		db = db.Where("(" + secured_filter + ")")
+	}
+	err = db.Find(&at).Error
+	return at, err
+}
+
+func (f *Fish) ApplicationTaskCreate(at *types.ApplicationTask) error {
+	if at.Task == "" {
+		return fmt.Errorf("Fish: Task can't be empty")
+	}
+	if at.Options == "" {
+		at.Options = util.UnparsedJson("{}")
+	}
+	if at.Result == "" {
+		at.Result = util.UnparsedJson("{}")
+	}
+
+	at.UID = f.NewUID()
+	return f.db.Create(at).Error
+}
+
+func (f *Fish) ApplicationTaskSave(at *types.ApplicationTask) error {
+	return f.db.Save(at).Error
+}
+
+func (f *Fish) ApplicationTaskGet(uid types.ApplicationTaskUID) (at *types.ApplicationTask, err error) {
+	at = &types.ApplicationTask{}
+	err = f.db.First(at, uid).Error
+	return at, err
+}
+
+func (f *Fish) ApplicationTaskListByApplication(app_uid types.ApplicationUID) (at []types.ApplicationTask, err error) {
+	err = f.db.Where("application_uid = ?", app_uid).Order("created_at desc").Find(&at).Error
+	return at, err
+}

--- a/lib/fish/fish.go
+++ b/lib/fish/fish.go
@@ -170,7 +170,7 @@ func (f *Fish) Init() error {
 			if err := f.ResourceDelete(res.UID); err != nil {
 				log.Println("Fish: Unable to delete Resource of Application:", res.ApplicationUID, err)
 			}
-			app_state := &types.ApplicationState{ApplicationUID: res.ApplicationUID, Status: types.ApplicationStateStatusERROR,
+			app_state := &types.ApplicationState{ApplicationUID: res.ApplicationUID, Status: types.ApplicationStatusERROR,
 				Description: "Found not cleaned up resource",
 			}
 			f.ApplicationStateCreate(app_state)
@@ -349,7 +349,7 @@ func (f *Fish) voteProcessRound(vote *types.Vote) {
 					log.Println("Fish: Unable to get the Application state:", err)
 					continue
 				}
-				if s.Status != types.ApplicationStateStatusNEW {
+				if s.Status != types.ApplicationStatusNEW {
 					// The Application state was changed by some node, so we can drop the election process
 					f.voteActiveRemove(vote.UID)
 					return
@@ -467,9 +467,9 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 	go func() {
 		log.Println("Fish: Start executing Application", app.UID, app_state.Status)
 
-		if app_state.Status == types.ApplicationStateStatusNEW {
+		if app_state.Status == types.ApplicationStatusNEW {
 			// Set Application state as ELECTED
-			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusELECTED,
+			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusELECTED,
 				Description: "Elected node: " + f.node.Name,
 			}
 			err := f.ApplicationStateCreate(app_state)
@@ -487,21 +487,21 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 		var metadata map[string]interface{}
 		if err := json.Unmarshal([]byte(app.Metadata), &metadata); err != nil {
 			log.Println("Fish: Unable to parse the app metadata:", app.UID, err)
-			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusERROR,
+			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusERROR,
 				Description: fmt.Sprintf("Unable to parse the app metadata: %s", err),
 			}
 			f.ApplicationStateCreate(app_state)
 		}
 		if err := json.Unmarshal([]byte(label.Metadata), &metadata); err != nil {
 			log.Println("Fish: Unable to parse the Label metadata:", label.UID, err)
-			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusERROR,
+			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusERROR,
 				Description: fmt.Sprintf("Unable to parse the label metadata: %s", err),
 			}
 			f.ApplicationStateCreate(app_state)
 		}
 		if merged_metadata, err = json.Marshal(metadata); err != nil {
 			log.Println("Fish: Unable to merge metadata:", label.UID, err)
-			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusERROR,
+			app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusERROR,
 				Description: fmt.Sprintf("Unable to merge metadata: %s", err),
 			}
 			f.ApplicationStateCreate(app_state)
@@ -513,11 +513,11 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 			NodeUID:        f.node.UID,
 			Metadata:       util.UnparsedJson(merged_metadata),
 		}
-		if app_state.Status == types.ApplicationStateStatusALLOCATED {
+		if app_state.Status == types.ApplicationStatusALLOCATED {
 			res, err = f.ResourceGetByApplication(app.UID)
 			if err != nil {
 				log.Println("Fish: Unable to get the allocated resource for Application:", app.UID, err)
-				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusERROR,
+				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusERROR,
 					Description: fmt.Sprintf("Unable to find the allocated resource: %s", err),
 				}
 				f.ApplicationStateCreate(app_state)
@@ -525,21 +525,24 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 		}
 
 		// Allocate the resource
-		if app_state.Status == types.ApplicationStateStatusELECTED {
+		if app_state.Status == types.ApplicationStatusELECTED {
 			// Run the allocation
 			log.Println("Fish: Allocate the resource using the driver", driver.Name())
-			res.HwAddr, res.IpAddr, err = driver.Allocate(string(label.Definition), metadata)
+			drv_res, err := driver.Allocate(string(label.Definition), metadata)
 			if err != nil {
 				log.Println("Fish: Unable to allocate resource for the Application:", app.UID, err)
-				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusERROR,
+				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusERROR,
 					Description: fmt.Sprintf("Driver allocate resource error: %s", err),
 				}
 			} else {
+				res.Identifier = drv_res.Identifier
+				res.HwAddr = drv_res.HwAddr
+				res.IpAddr = drv_res.IpAddr
 				err := f.ResourceCreate(res)
 				if err != nil {
 					log.Println("Fish: Unable to store resource for Application:", app.UID, err)
 				}
-				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusALLOCATED,
+				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusALLOCATED,
 					Description: fmt.Sprintf("Driver allocated the resource"),
 				}
 			}
@@ -548,7 +551,7 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 
 		// Run the loop to wait for deallocate request
 		var deallocate_retry uint8 = 1
-		for app_state.Status == types.ApplicationStateStatusALLOCATED {
+		for app_state.Status == types.ApplicationStatusALLOCATED {
 			if !f.running {
 				log.Println("Fish: Stopping the Application execution:", app.UID)
 				return
@@ -557,39 +560,16 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 			if err != nil {
 				log.Println("Fish: Unable to get status for Application:", app.UID, err)
 			}
-			if app_state.Status == types.ApplicationStateStatusALLOCATED {
-				// Execute the associated ApplicationTasks if there is some
-				tasks, err := f.ApplicationTaskListByApplication(app.UID)
-				if err != nil {
-					log.Println("Fish: Unable to get ApplicationTasks:", app.UID, err)
-				}
-				for _, task := range tasks {
-					// Skipping already executed task
-					if task.Result != "{}" {
-						continue
-					}
-					t := driver.GetTask(task.Task, string(task.Options))
-					if t == nil {
-						log.Println("Fish: Unable to get associated driver task type for Application:", app.UID, task.Task)
-						task.Result = util.UnparsedJson(`{"error":"task not availble in driver"}`)
-					} else {
-						// Executing the task
-						result, err := t.Execute(res.HwAddr)
-						if err != nil {
-							// We're not crashing here because even with error task could have a result
-							log.Println("Fish: Error happened during executing the task:", task.UID, err)
-						}
-						task.Result = util.UnparsedJson(result)
-					}
-					if err := f.ApplicationTaskSave(&task); err != nil {
-						log.Println("Fish: Error during update the task with result:", task.UID, err)
-					}
-				}
-			}
-			if app_state.Status == types.ApplicationStateStatusDEALLOCATE || app_state.Status == types.ApplicationStateStatusRECALLED {
+
+			// Execute the existing ApplicationTasks. It will be executed during ALLOCATED or prior
+			// to executing deallocation by DEALLOCATE & RECALLED which right now is useful for
+			// `snapshot` tasks.
+			f.executeApplicationTasks(driver, res, app_state.Status)
+
+			if app_state.Status == types.ApplicationStatusDEALLOCATE || app_state.Status == types.ApplicationStatusRECALLED {
 				log.Println("Fish: Running Deallocate of the Application:", app.UID)
 				// Deallocating and destroy the resource
-				if err := driver.Deallocate(res.HwAddr); err != nil {
+				if err := driver.Deallocate(res); err != nil {
 					log.Printf("Fish: Unable to deallocate the Resource of Application: %s (try: %d): %v\n", app.UID, deallocate_retry, err)
 					// Let's retry to deallocate the resource 10 times before give up
 					if deallocate_retry <= 10 {
@@ -597,12 +577,12 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 						time.Sleep(10 * time.Second)
 						continue
 					}
-					app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusERROR,
+					app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusERROR,
 						Description: fmt.Sprintf("Driver deallocate resource error: %s", err),
 					}
 				} else {
 					log.Println("Fish: Successful deallocation of the Application:", app.UID)
-					app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStateStatusDEALLOCATED,
+					app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusDEALLOCATED,
 						Description: fmt.Sprintf("Driver deallocated the resource"),
 					}
 				}
@@ -635,6 +615,37 @@ func (f *Fish) executeApplication(app_uid types.ApplicationUID) error {
 	}()
 
 	return nil
+}
+
+func (f *Fish) executeApplicationTasks(drv drivers.ResourceDriver, res *types.Resource, app_status types.ApplicationStatus) {
+	// Execute the associated ApplicationTasks if there is some
+	tasks, err := f.ApplicationTaskListByApplicationAndWhen(res.ApplicationUID, app_status)
+	if err != nil {
+		log.Println("Fish: Unable to get ApplicationTasks:", res.ApplicationUID, err)
+	}
+	for _, task := range tasks {
+		// Skipping already executed task
+		if task.Result != "{}" {
+			continue
+		}
+		t := drv.GetTask(task.Task, string(task.Options))
+		if t == nil {
+			log.Println("Fish: Unable to get associated driver task type for Application:", res.ApplicationUID, task.Task)
+			task.Result = util.UnparsedJson(`{"error":"task not availble in driver"}`)
+		} else {
+			// Executing the task
+			t.SetInfo(&task, res)
+			result, err := t.Execute()
+			if err != nil {
+				// We're not crashing here because even with error task could have a result
+				log.Println("Fish: Error happened during executing the task:", task.UID, err)
+			}
+			task.Result = util.UnparsedJson(result)
+		}
+		if err := f.ApplicationTaskSave(&task); err != nil {
+			log.Println("Fish: Error during update the task with result:", task.UID, err)
+		}
+	}
 }
 
 func (f *Fish) removeFromExecutingApplincations(app_uid types.ApplicationUID) {

--- a/lib/fish/resource.go
+++ b/lib/fish/resource.go
@@ -46,8 +46,8 @@ func (f *Fish) ResourceListNode(node_uid types.NodeUID) (rs []types.Resource, er
 }
 
 func (f *Fish) ResourceCreate(r *types.Resource) error {
-	if len(r.HwAddr) == 0 {
-		return fmt.Errorf("Fish: HwAddr can't be empty")
+	if len(r.Identifier) == 0 {
+		return fmt.Errorf("Fish: Identifier can't be empty")
 	}
 	// TODO: check JSON
 	if len(r.Metadata) < 2 {

--- a/lib/fish/user.go
+++ b/lib/fish/user.go
@@ -73,7 +73,7 @@ func (f *Fish) UserAuth(name string, password string) *types.User {
 	return user
 }
 
-func (f *Fish) UserNew(name string, password string) (string, error) {
+func (f *Fish) UserNew(name string, password string) (string, *types.User, error) {
 	if password == "" {
 		password = crypt.RandString(64)
 	}
@@ -82,10 +82,10 @@ func (f *Fish) UserNew(name string, password string) (string, error) {
 
 	if err := f.UserCreate(user); err != nil {
 		log.Printf("Fish: Unable to create new user: %s, %s", name, err)
-		return "", err
+		return "", nil, err
 	}
 
-	return password, nil
+	return password, user, nil
 }
 
 func (f *Fish) UserDelete(name string) error {

--- a/lib/openapi/api/api_v1.go
+++ b/lib/openapi/api/api_v1.go
@@ -357,10 +357,10 @@ func (e *Processor) ApplicationDeallocateGet(c echo.Context, uid types.Applicati
 		return fmt.Errorf("Unable to deallocate the Application with status: %s", out.Status)
 	}
 
-	new_status := types.ApplicationStateStatusDEALLOCATE
-	if out.Status != types.ApplicationStateStatusALLOCATED {
+	new_status := types.ApplicationStatusDEALLOCATE
+	if out.Status != types.ApplicationStatusALLOCATED {
 		// The Application was not yet Allocated so just mark it as Recalled
-		new_status = types.ApplicationStateStatusRECALLED
+		new_status = types.ApplicationStatusRECALLED
 	}
 	as := &types.ApplicationState{ApplicationUID: uid, Status: new_status,
 		Description: fmt.Sprintf("Requested by user %s", user.(*types.User).Name),

--- a/lib/openapi/api/api_v1.go
+++ b/lib/openapi/api/api_v1.go
@@ -100,19 +100,29 @@ func (e *Processor) UserCreatePost(c echo.Context) error {
 		return fmt.Errorf("Only 'admin' user can create user")
 	}
 
-	var data types.User
+	var data types.UserAPIPassword
 	if err := c.Bind(&data); err != nil {
 		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Wrong request body: %v", err)})
 		return fmt.Errorf("Wrong request body: %w", err)
 	}
 
-	password, err := e.fish.UserNew(data.Name, "") // Generate new password for now
+	password, new_user, err := e.fish.UserNew(data.Name, data.Password)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Unable to create user: %v", err)})
 		return fmt.Errorf("Unable to create user: %w", err)
 	}
 
-	return c.JSON(http.StatusOK, H{"password": password})
+	// Fill the output values
+	data.CreatedAt = new_user.CreatedAt
+	data.UpdatedAt = new_user.UpdatedAt
+	if data.Password == "" {
+		data.Password = password
+	} else {
+		data.Password = ""
+	}
+	data.Hash = new_user.Hash
+
+	return c.JSON(http.StatusOK, new_user)
 }
 
 func (e *Processor) UserDelete(c echo.Context, name string) error {
@@ -269,29 +279,58 @@ func (e *Processor) ApplicationStateGet(c echo.Context, uid types.ApplicationUID
 	return c.JSON(http.StatusOK, out)
 }
 
-func (e *Processor) ApplicationSnapshotGet(c echo.Context, uid types.ApplicationUID, params types.ApplicationSnapshotGetParams) error {
-	app, err := e.fish.ApplicationGet(uid)
+func (e *Processor) ApplicationTaskListGet(c echo.Context, app_uid types.ApplicationUID, params types.ApplicationTaskListGetParams) error {
+	app, err := e.fish.ApplicationGet(app_uid)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Unable to find the Application: %s", uid)})
-		return fmt.Errorf("Unable to find the Application: %s, %w", uid, err)
+		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Unable to find the Application: %s", app_uid)})
+		return fmt.Errorf("Unable to find the Application: %s, %w", app_uid, err)
 	}
 
-	// Only the owner of the application (or admin) could take the snapshot of the resource
+	// Only the owner of the application (or admin) could get the tasks
 	user := c.Get("user")
 	if app.OwnerName != user.(*types.User).Name && user.(*types.User).Name != "admin" {
-		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Only the owner & admin can take snapshot of the Application resource")})
-		return fmt.Errorf("Only the owner & admin can take snapshot of the Application resource")
+		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Only the owner of Application & admin can get the Application Tasks")})
+		return fmt.Errorf("Only the owner of Application & admin can get the Application Tasks")
 	}
 
-	// TODO: not working correctly in cluster in case not all the nodes supports the
-	// driver - need to rewrite in cluster way as Resource Tasks.
-	full := params.Full != nil && *params.Full
-	out, err := e.fish.ApplicationSnapshot(app, full)
+	out, err := e.fish.ApplicationTaskFindByApplication(app_uid, params.Filter)
 	if err != nil {
-		c.JSON(http.StatusNotFound, H{"message": fmt.Sprintf("Error during creating Application snapshot: %v", err)})
+		c.JSON(http.StatusInternalServerError, H{"message": fmt.Sprintf("Unable to get the Application Tasks list: %v", err)})
+		return fmt.Errorf("Unable to get the Application Tasks list: %w", err)
 	}
 
-	return c.JSON(http.StatusOK, H{"data": out})
+	return c.JSON(http.StatusOK, out)
+}
+
+func (e *Processor) ApplicationTaskCreatePost(c echo.Context, app_uid types.ApplicationUID) error {
+	app, err := e.fish.ApplicationGet(app_uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Unable to find the Application: %s", app_uid)})
+		return fmt.Errorf("Unable to find the Application: %s, %w", app_uid, err)
+	}
+
+	// Only the owner of the application (or admin) could create the tasks
+	user := c.Get("user")
+	if app.OwnerName != user.(*types.User).Name && user.(*types.User).Name != "admin" {
+		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Only the owner of Application & admin can create the Application Tasks")})
+		return fmt.Errorf("Only the owner of Application & admin can create the Application Tasks")
+	}
+
+	var data types.ApplicationTask
+	if err := c.Bind(&data); err != nil {
+		c.JSON(http.StatusBadRequest, H{"error": fmt.Sprintf("Wrong request body: %v", err)})
+		return fmt.Errorf("Wrong request body: %w", err)
+	}
+
+	// Set Application UID for the task forcefully to not allow creating tasks for the other Apps
+	data.ApplicationUID = app_uid
+
+	if err := e.fish.ApplicationTaskCreate(&data); err != nil {
+		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Unable to create ApplicationTask: %v", err)})
+		return fmt.Errorf("Unable to create ApplicationTask: %w", err)
+	}
+
+	return c.JSON(http.StatusOK, data)
 }
 
 func (e *Processor) ApplicationDeallocateGet(c echo.Context, uid types.ApplicationUID) error {

--- a/tests/application_task_notexisting_fail_test.go
+++ b/tests/application_task_notexisting_fail_test.go
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
+// Ensure application task could be created with weird name but will fail during execution
+func Test_application_task_notexisting_fail(t *testing.T) {
+	t.Parallel()
+	afi := RunAquariumFish(t, `---
+node_name: node-1
+node_location: test_loc
+
+api_address: 127.0.0.1:0
+
+drivers:
+  - name: test`)
+
+	t.Cleanup(func() {
+		afi.Cleanup()
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label types.Label
+	t.Run("Create Label", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label", "version":1, "driver":"test", "definition": {"resources":{"cpu":1,"ram":2}}}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	var app types.Application
+	t.Run("Create Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/")).
+			JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app)
+
+		if app.UID == uuid.Nil {
+			t.Fatalf("Application UID is incorrect: %v", app.UID)
+		}
+	})
+
+	var app_state types.ApplicationState
+	t.Run("Application should get ALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+
+	var app_task types.ApplicationTask
+	t.Run("Create ApplicationTask Snapshot", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/task/")).
+			JSON(`{"task":"NOTEXISTING_TASK"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app_task)
+
+		if app_task.UID == uuid.Nil {
+			t.Fatalf("ApplicationTask UID is incorrect: %v", app_task.UID)
+		}
+	})
+
+	var app_tasks []types.ApplicationTask
+	t.Run("ApplicationTask should be executed as not found in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/task/")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_tasks)
+
+			if len(app_tasks) != 1 {
+				r.Fatalf("Application Tasks list is empty")
+			}
+			if app_tasks[0].UID != app_task.UID {
+				r.Fatalf("ApplicationTask UID is incorrect: %v != %v", app_tasks[0].UID, app_task.UID)
+			}
+			if string(app_tasks[0].Result) != `{"error":"task not availble in driver"}` {
+				r.Fatalf("ApplicationTask result is incorrect: %v", app_tasks[0].Result)
+			}
+		})
+	})
+
+	t.Run("Deallocate the Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/deallocate")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End()
+	})
+
+	t.Run("Application should get DEALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+}

--- a/tests/application_task_notexisting_fail_test.go
+++ b/tests/application_task_notexisting_fail_test.go
@@ -101,7 +101,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -112,7 +112,7 @@ drivers:
 		apitest.New().
 			EnableNetworking(cli).
 			Post(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/task/")).
-			JSON(`{"task":"NOTEXISTING_TASK"}`).
+			JSON(map[string]any{"task": "NOTEXISTING_TASK", "when": types.ApplicationStatusALLOCATED}).
 			BasicAuth("admin", afi.AdminToken()).
 			Expect(t).
 			Status(http.StatusOK).
@@ -169,7 +169,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 		})

--- a/tests/application_task_snapshot_by_user_test.go
+++ b/tests/application_task_snapshot_by_user_test.go
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
+// Ensure application task interface snapshot for user is working
+func Test_application_task_snapshot_by_user(t *testing.T) {
+	t.Parallel()
+	afi := RunAquariumFish(t, `---
+node_name: node-1
+node_location: test_loc
+
+api_address: 127.0.0.1:0
+
+drivers:
+  - name: test`)
+
+	t.Cleanup(func() {
+		afi.Cleanup()
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label types.Label
+	t.Run("Create Label", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label", "version":1, "driver":"test", "definition": {"resources":{"cpu":1,"ram":2}}}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	t.Run("Create User", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/user/")).
+			JSON(`{"name":"test-user", "password":"test-user-password"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	var app types.Application
+	t.Run("Create Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/")).
+			JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+			BasicAuth("test-user", "test-user-password").
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app)
+
+		if app.UID == uuid.Nil {
+			t.Fatalf("Application UID is incorrect: %v", app.UID)
+		}
+	})
+
+	var app_state types.ApplicationState
+	t.Run("Application should get ALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("test-user", "test-user-password").
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+
+	var res types.Resource
+	t.Run("Resource should be created", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/resource")).
+			BasicAuth("test-user", "test-user-password").
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&res)
+
+		if res.HwAddr == "" {
+			t.Fatalf("Resource hwaddr is incorrect: %v", res.HwAddr)
+		}
+	})
+
+	var app_task types.ApplicationTask
+	t.Run("Create ApplicationTask Snapshot", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/task/")).
+			JSON(`{"task":"snapshot"}`).
+			BasicAuth("test-user", "test-user-password").
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app_task)
+
+		if app_task.UID == uuid.Nil {
+			t.Fatalf("ApplicationTask UID is incorrect: %v", app_task.UID)
+		}
+	})
+
+	var app_tasks []types.ApplicationTask
+	t.Run("ApplicationTask should be executed in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/task/")).
+				BasicAuth("test-user", "test-user-password").
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_tasks)
+
+			if len(app_tasks) != 1 {
+				r.Fatalf("Application Tasks list is empty")
+			}
+			if app_tasks[0].UID != app_task.UID {
+				r.Fatalf("ApplicationTask UID is incorrect: %v != %v", app_tasks[0].UID, app_task.UID)
+			}
+			if string(app_tasks[0].Result) != `{"snapshots":["test-snapshot"]}` {
+				r.Fatalf("ApplicationTask result is incorrect: %v", app_tasks[0].Result)
+			}
+		})
+	})
+
+	t.Run("Deallocate the Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/deallocate")).
+			BasicAuth("test-user", "test-user-password").
+			Expect(t).
+			Status(http.StatusOK).
+			End()
+	})
+
+	t.Run("Application should get DEALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("test-user", "test-user-password").
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+}

--- a/tests/cant_allocate_too_big_label_test.go
+++ b/tests/cant_allocate_too_big_label_test.go
@@ -109,7 +109,7 @@ drivers:
 			End().
 			JSON(&app_state)
 
-		if app_state.Status != types.ApplicationStateStatusNEW {
+		if app_state.Status != types.ApplicationStatusNEW {
 			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
 		}
 	})
@@ -126,7 +126,7 @@ drivers:
 			End().
 			JSON(&app_state)
 
-		if app_state.Status != types.ApplicationStateStatusNEW {
+		if app_state.Status != types.ApplicationStatusNEW {
 			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
 		}
 	})
@@ -143,7 +143,7 @@ drivers:
 			End().
 			JSON(&app_state)
 
-		if app_state.Status != types.ApplicationStateStatusNEW {
+		if app_state.Status != types.ApplicationStatusNEW {
 			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
 		}
 	})
@@ -160,7 +160,7 @@ drivers:
 			End().
 			JSON(&app_state)
 
-		if app_state.Status != types.ApplicationStateStatusNEW {
+		if app_state.Status != types.ApplicationStatusNEW {
 			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
 		}
 	})
@@ -186,7 +186,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusRECALLED {
+			if app_state.Status != types.ApplicationStatusRECALLED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 		})

--- a/tests/generated_uids_prefix_is_node_prefix_test.go
+++ b/tests/generated_uids_prefix_is_node_prefix_test.go
@@ -140,7 +140,7 @@ drivers:
 				t.Fatalf("ApplicationState UID is incorrect: %v", app_state.UID)
 			}
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 
@@ -165,8 +165,8 @@ drivers:
 			t.Fatalf("Resource UID is incorrect: %v", res.UID)
 		}
 
-		if res.HwAddr == "" {
-			t.Fatalf("Resource hwaddr is incorrect: %v", res.HwAddr)
+		if res.Identifier == "" {
+			t.Fatalf("Resource identifier is incorrect: %v", res.Identifier)
 		}
 
 		if !bytes.Equal(res.UID[:6], node.UID[:6]) {
@@ -195,7 +195,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 		})

--- a/tests/simple_app_create_destroy_test.go
+++ b/tests/simple_app_create_destroy_test.go
@@ -104,7 +104,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -121,8 +121,8 @@ drivers:
 			End().
 			JSON(&res)
 
-		if res.HwAddr == "" {
-			t.Fatalf("Resource hwaddr is incorrect: %v", res.HwAddr)
+		if res.Identifier == "" {
+			t.Fatalf("Resource identifier is incorrect: %v", res.Identifier)
 		}
 	})
 
@@ -147,7 +147,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
 			}
 		})

--- a/tests/three_apps_with_limit_test.go
+++ b/tests/three_apps_with_limit_test.go
@@ -141,7 +141,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application 1 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -158,7 +158,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application 2 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -174,7 +174,7 @@ drivers:
 			End().
 			JSON(&app_state)
 
-		if app_state.Status != types.ApplicationStateStatusNEW {
+		if app_state.Status != types.ApplicationStatusNEW {
 			t.Fatalf("Application 3 Status is incorrect: %v", app_state.Status)
 		}
 	})
@@ -210,7 +210,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application 1 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -227,7 +227,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application 2 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -244,7 +244,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application 3 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -271,7 +271,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application 3 Status is incorrect: %v", app_state.Status)
 			}
 		})

--- a/tests/two_apps_with_limit_test.go
+++ b/tests/two_apps_with_limit_test.go
@@ -126,7 +126,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application 1 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -142,7 +142,7 @@ drivers:
 			End().
 			JSON(&app_state)
 
-		if app_state.Status != types.ApplicationStateStatusNEW {
+		if app_state.Status != types.ApplicationStatusNEW {
 			t.Fatalf("Application 2 Status is incorrect: %v", app_state.Status)
 		}
 	})
@@ -158,8 +158,8 @@ drivers:
 			End().
 			JSON(&res)
 
-		if res.HwAddr == "" {
-			t.Fatalf("Resource 1 hwaddr is incorrect: %v", res.HwAddr)
+		if res.Identifier == "" {
+			t.Fatalf("Resource 1 identifier is incorrect: %v", res.Identifier)
 		}
 	})
 
@@ -184,7 +184,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application 1 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -201,7 +201,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusALLOCATED {
+			if app_state.Status != types.ApplicationStatusALLOCATED {
 				r.Fatalf("Application 2 Status is incorrect: %v", app_state.Status)
 			}
 		})
@@ -217,8 +217,8 @@ drivers:
 			End().
 			JSON(&res)
 
-		if res.HwAddr == "" {
-			t.Fatalf("Resource 2 hwaddr is incorrect: %v", res.HwAddr)
+		if res.Identifier == "" {
+			t.Fatalf("Resource 2 identifier is incorrect: %v", res.Identifier)
 		}
 	})
 
@@ -243,7 +243,7 @@ drivers:
 				End().
 				JSON(&app_state)
 
-			if app_state.Status != types.ApplicationStateStatusDEALLOCATED {
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
 				r.Fatalf("Application 2 Status is incorrect: %v", app_state.Status)
 			}
 		})


### PR DESCRIPTION
The change is quite big due to alot of design flaws was rethought. In general it adds ApplicationTask struct, but also seriously changed the driver & resource structs & interfaces.

* Added when field to ApplicationTask to specify when to execute task - especially useful for `snapshot` to execute before DEALLOCATE
* Moved ApplicationStatus aside to use in ApplicationTask `when` field
* Redesigned Resource to put identifier field in it in order to use hwaddr only by it's direct purpose.
* The driver Allocate/Status/Deallocate interfaces was moved to direct use of Resource instead of basic types - I think it's much more convenient, because we would not need to change interfaces much and they will be much more stable in time. Drivers would be able to use struct fields and if we adding a new one it's not a big deal for them.
* Added task and resource info to the task execution
* AWS: Now sets friendly name for the instance
* VMX: Now uses vmx path as the primary resources identifier
* Clarified the CI workflow info & added xml report

## Related Issue

fixes: #32 
relates: #12

## How Has This Been Tested?

Automatically

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.