### PR TITLE
Added lifetime for the Resources in Label definition

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1206,15 +1206,18 @@ components:
         - multitenancy
         - cpu_overbook
         - ram_overbook
+        - lifetime
       properties:
         cpu:
           x-go-type: uint
           type: integer
           minimum: 0
+          description: Amount of vCPUs (logical CPU with HT enabled will have 2 per core)
         ram:
           x-go-type: uint
           type: integer
           minimum: 0
+          description: Amount of RAM in GB
         disks:
           type: object
           additionalProperties:
@@ -1231,6 +1234,13 @@ components:
         ram_overbook:
           type: boolean
           description: Tolerate to RAM overbooking when executed together with other envs
+        lifetime:
+          type: string
+          description: |
+            Total lifetime of the resource in Time Duration (ex. "1h30m30s"). Begins on Resource
+            create time till deallocate by user or auto deallocate by timeout. If it's empty or "0"
+            then default value from fish node config will be used. If it's negative (ex. "-1s")
+            then the resource will live forever or until the user requests deallocate.
 
     ResourcesDisk:
       type: object

--- a/lib/fish/config.go
+++ b/lib/fish/config.go
@@ -13,8 +13,10 @@
 package fish
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/adobe/aquarium-fish/lib/util"
 	"github.com/ghodss/yaml"
@@ -34,6 +36,8 @@ type Config struct {
 
 	NodeName     string `json:"node_name"`     // Last resort in case you need to override the default host node name
 	NodeLocation string `json:"node_location"` // Specify cluster node location for multi-dc configurations
+
+	DefaultResourceLifetime string `json:"default_resource_lifetime"` // Sets the lifetime of the resource which will be used if label definition one is not set
 
 	Drivers []ConfigDriver `json:"drivers"` // If specified - only the listed plugins will be loaded
 }
@@ -63,6 +67,11 @@ func (c *Config) ReadConfigFile(cfg_path string) error {
 	}
 	if c.TLSCrt == "" {
 		c.TLSCrt = c.NodeName + ".crt"
+	}
+
+	_, err := time.ParseDuration(c.DefaultResourceLifetime)
+	if c.DefaultResourceLifetime != "" && err != nil {
+		return fmt.Errorf("Fish: Default Resource Lifetime parse error: %v", err)
 	}
 
 	return nil

--- a/lib/fish/label.go
+++ b/lib/fish/label.go
@@ -15,6 +15,7 @@ package fish
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/adobe/aquarium-fish/lib/openapi/types"
 	"github.com/adobe/aquarium-fish/lib/util"
@@ -48,6 +49,10 @@ func (f *Fish) LabelCreate(l *types.Label) error {
 		}
 		if def.Resources.Ram < 1 {
 			return fmt.Errorf("Fish: Resources RAM can't be less than 1 in Label Definition %d", i)
+		}
+		_, err := time.ParseDuration(def.Resources.Lifetime)
+		if def.Resources.Lifetime != "" && err != nil {
+			return fmt.Errorf("Fish: Resources Lifetime parse error in Label Definition %d: %v", i, err)
 		}
 		if def.Options == "" {
 			l.Definitions[i].Options = "{}"

--- a/tests/label_lifetime_timeout_test.go
+++ b/tests/label_lifetime_timeout_test.go
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
+// Checks the Application is getting deallocated by timeout
+func Test_label_lifetime_timeout(t *testing.T) {
+	t.Parallel()
+	afi := RunAquariumFish(t, `---
+node_name: node-1
+node_location: test_loc
+
+api_address: 127.0.0.1:0
+
+drivers:
+  - name: test`)
+
+	t.Cleanup(func() {
+		afi.Cleanup()
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label types.Label
+	t.Run("Create Label", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label", "version":1, "definitions": [
+				{"driver":"test","resources":{"cpu":1,"ram":2,"lifetime":"15s"}}
+			]}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	var app types.Application
+	t.Run("Create Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/")).
+			JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app)
+
+		if app.UID == uuid.Nil {
+			t.Fatalf("Application UID is incorrect: %v", app.UID)
+		}
+	})
+
+	var app_state types.ApplicationState
+	t.Run("Application should get ALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStatusALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+
+	time.Sleep(10 * time.Second)
+
+	t.Run("Application should be still ALLOCATED in 10 sec", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app_state)
+
+		if app_state.Status != types.ApplicationStatusALLOCATED {
+			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
+		}
+	})
+
+	t.Run("Application should get DEALLOCATED in 5 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 5 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+}


### PR DESCRIPTION
With lifetime timeout we can be sure the application resource will not be executed forever if something bad happened and based on this timeout fish node will be able to do some heuristics on how much time left till provisioning the next resource (#38).

The duration is set in standard golang format as string "1h2m3s", if it's empty or 0 - the default from fish config will be used. And if it's negative (like "-1s") then the resource should exist until user say so by deallocating it.

This change really helps with clouds where we certainly don't need to left the resources for long time.

## Related Issue

fixes: #28 

## How Has This Been Tested?

Automatically

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

