### PR TITLE
Fixed an issue with default lifetime & added some tests for that

### DIFF
--- a/examples/create_user.sh
+++ b/examples/create_user.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+#
+# This example script creates test user with predefined password
+#
+
+token=$1
+[ "$token" ] || exit 1
+
+label_id=$(curl -s -u "admin:$token" -k -X POST -H 'Content-Type: application/json' -d '{
+    "name":"test-user",
+    "password":"test-user-password"
+}' https://localhost:8001/api/v1/user/)

--- a/lib/fish/fish.go
+++ b/lib/fish/fish.go
@@ -579,9 +579,11 @@ func (f *Fish) executeApplication(vote types.Vote) error {
 		resource_lifetime, err := time.ParseDuration(label_def.Resources.Lifetime)
 		if label_def.Resources.Lifetime != "" && err != nil {
 			log.Println("Fish: Error: Can't parse the Lifetime from Label Definition:", label.UID, res.DefinitionIndex)
-			// Trying to get default value from fish config
+		}
+		if err != nil {
+			// Try to get default value from fish config
 			resource_lifetime, err = time.ParseDuration(f.cfg.DefaultResourceLifetime)
-			if f.cfg.DefaultResourceLifetime != "" && err != nil {
+			if err != nil {
 				// Not fatal error - in worst case the resource will just sit there but at least will
 				// not ruin the workload execution
 				log.Println("Fish: Error: Can't parse the Default Resource Lifetime from fish config")

--- a/tests/default_lifetime_timeout_test.go
+++ b/tests/default_lifetime_timeout_test.go
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
+// Checks the Application is getting deallocated by default timeout in node config
+func Test_default_lifetime_timeout(t *testing.T) {
+	t.Parallel()
+	afi := RunAquariumFish(t, `---
+node_name: node-1
+node_location: test_loc
+default_resource_lifetime: 15s
+
+api_address: 127.0.0.1:0
+
+drivers:
+  - name: test`)
+
+	t.Cleanup(func() {
+		afi.Cleanup()
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label types.Label
+	t.Run("Create Label", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label", "version":1, "definitions": [
+				{"driver":"test","resources":{"cpu":1,"ram":2}}
+			]}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	var app types.Application
+	t.Run("Create Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/")).
+			JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app)
+
+		if app.UID == uuid.Nil {
+			t.Fatalf("Application UID is incorrect: %v", app.UID)
+		}
+	})
+
+	var app_state types.ApplicationState
+	t.Run("Application should get ALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStatusALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+
+	time.Sleep(10 * time.Second)
+
+	t.Run("Application should be still ALLOCATED in 10 sec", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app_state)
+
+		if app_state.Status != types.ApplicationStatusALLOCATED {
+			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
+		}
+	})
+
+	t.Run("Application should get DEALLOCATED in 5 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 5 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+}

--- a/tests/label_overrides_default_lifetime_timeout_test.go
+++ b/tests/label_overrides_default_lifetime_timeout_test.go
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+)
+
+// Checks the Application is getting deallocated by label rather than default timeout in node config
+func Test_label_overrides_default_lifetime_timeout(t *testing.T) {
+	t.Parallel()
+	afi := RunAquariumFish(t, `---
+node_name: node-1
+node_location: test_loc
+default_resource_lifetime: 5s
+
+api_address: 127.0.0.1:0
+
+drivers:
+  - name: test`)
+
+	t.Cleanup(func() {
+		afi.Cleanup()
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label types.Label
+	t.Run("Create Label", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/label/")).
+			JSON(`{"name":"test-label", "version":1, "definitions": [
+				{"driver":"test","resources":{"cpu":1,"ram":2,"lifetime":"15s"}}
+			]}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	var app types.Application
+	t.Run("Create Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.ApiAddress("api/v1/application/")).
+			JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app)
+
+		if app.UID == uuid.Nil {
+			t.Fatalf("Application UID is incorrect: %v", app.UID)
+		}
+	})
+
+	var app_state types.ApplicationState
+	t.Run("Application should get ALLOCATED in 10 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStatusALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+
+	time.Sleep(10 * time.Second)
+
+	t.Run("Application should be still ALLOCATED in 10 sec", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app_state)
+
+		if app_state.Status != types.ApplicationStatusALLOCATED {
+			t.Fatalf("Application Status is incorrect: %v", app_state.Status)
+		}
+	})
+
+	t.Run("Application should get DEALLOCATED in 5 sec", func(t *testing.T) {
+		Retry(&Timer{Timeout: 5 * time.Second, Wait: 1 * time.Second}, t, func(r *R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.ApiAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&app_state)
+
+			if app_state.Status != types.ApplicationStatusDEALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", app_state.Status)
+			}
+		})
+	})
+}


### PR DESCRIPTION
A small fix for not properly working lifetime in fish node configuration - also added a couple of tests to ensure it will work properly & label lifetime will override the default one.

## Related Issue

Caused by: #39 

## How Has This Been Tested?

Automatically

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

