### PR TITLE
Solved issue with cleanup after fail and a number of bugfixes for AWS

### DIFF
--- a/lib/drivers/aws/driver.go
+++ b/lib/drivers/aws/driver.go
@@ -399,7 +399,7 @@ func (d *Driver) Allocate(def types.LabelDefinition, metadata map[string]any) (*
 			if timeout < 0 {
 				break
 			}
-			time.Sleep(5)
+			time.Sleep(5 * time.Second)
 
 			inst_tmp, err := d.getInstance(conn, *inst.InstanceId)
 			if err == nil && inst_tmp != nil {
@@ -454,7 +454,7 @@ func (d *Driver) Allocate(def types.LabelDefinition, metadata map[string]any) (*
 		if timeout < 0 {
 			break
 		}
-		time.Sleep(5)
+		time.Sleep(5 * time.Second)
 
 		inst_tmp, err := d.getInstance(conn, *inst.InstanceId)
 		if err == nil && inst_tmp != nil {
@@ -466,7 +466,7 @@ func (d *Driver) Allocate(def types.LabelDefinition, metadata map[string]any) (*
 	}
 
 	res.Identifier = *inst.InstanceId
-	return res, log.Error("AWS: Unable to locate the instance IP:", *inst.InstanceId)
+	return res, log.Error("AWS: Unable to locate the instance IP:", i_name, *inst.InstanceId)
 }
 
 func (d *Driver) Status(res *types.Resource) (string, error) {

--- a/lib/fish/drivers.go
+++ b/lib/fish/drivers.go
@@ -71,6 +71,7 @@ func (f *Fish) DriversSet() error {
 }
 
 func (f *Fish) DriversPrepare(configs []ConfigDriver) (errs []error) {
+	not_skipped_drivers := drivers_enabled_list[:0]
 	for _, drv := range drivers_enabled_list {
 		// Looking for the driver config
 		var json_cfg []byte
@@ -83,10 +84,14 @@ func (f *Fish) DriversPrepare(configs []ConfigDriver) (errs []error) {
 
 		if err := drv.Prepare(json_cfg); err != nil {
 			errs = append(errs, err)
-			log.Info("Fish: Resource driver skipped:", drv.Name())
+			log.Warn("Fish: Resource driver prepare failed:", drv.Name(), err)
 		} else {
+			not_skipped_drivers = append(not_skipped_drivers, drv)
 			log.Info("Fish: Resource driver activated:", drv.Name())
 		}
 	}
+
+	drivers_enabled_list = not_skipped_drivers
+
 	return errs
 }


### PR DESCRIPTION
Now images and VMX Allocation cleans up if something bad happened during the process. And this change also contains a number of bugfixes for AWS driver.

* Cleanup is quite an important feature, otherwise automated Fish is clogging the disk or leftovers from the bad allocations. Also it's good to clean if images was not downloaded/unpacked correctly (I'm looking at you, max opened files on mac!)
* Removing driver from the list if it failed preparation phase - if they are not prepared, so what's the point of having them in the roster...
* 1 minute retry AWS connection on start in case network is not working - caught on mac after reboot, service starts and gets no internet...
* Fixed nasty issue with waiting of AWS instance IP and disks - it sometimes don't get the IP immediately and just waits for 5 microseconds and repeats with 0 result of course.


## Related Issue

fixes: #6 

## How Has This Been Tested?

Automatically

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

