### PR TITLE
BUGFIX: Allocated restart and VMX hard stop

### DIFF
--- a/lib/drivers/test/config.go
+++ b/lib/drivers/test/config.go
@@ -14,12 +14,16 @@ package test
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 
 	"github.com/adobe/aquarium-fish/lib/log"
 )
 
 type Config struct {
 	IsRemote bool `json:"is_remote"` // Pretend to be remote or not to check the local node limits
+
+	WorkspacePath string `json:"workspace_path"` // Where to place the files of running resources
 
 	CpuLimit uint `json:"cpu_limit"` // Number of available virtual CPUs, 0 - unlimited
 	RamLimit uint `json:"ram_limit"` // Amount of available virtual RAM (GB), 0 - unlimited
@@ -46,5 +50,15 @@ func (c *Config) Apply(config []byte) error {
 }
 
 func (c *Config) Validate() (err error) {
+	if c.WorkspacePath == "" {
+		c.WorkspacePath = "fish_test_workspace"
+	}
+	if c.WorkspacePath, err = filepath.Abs(c.WorkspacePath); err != nil {
+		return err
+	}
+	log.Debug("TEST: Creating working directory:", c.WorkspacePath)
+	if err := os.MkdirAll(c.WorkspacePath, 0o750); err != nil {
+		return err
+	}
 	return randomFail("ConfigValidate", c.FailConfigValidate)
 }

--- a/lib/drivers/test/tasks.go
+++ b/lib/drivers/test/tasks.go
@@ -15,6 +15,8 @@ package test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/adobe/aquarium-fish/lib/drivers"
 	"github.com/adobe/aquarium-fish/lib/log"
@@ -56,10 +58,8 @@ func (t *TaskSnapshot) Execute() (result []byte, err error) {
 		return out, log.Error("TEST: RandomFail:", err)
 	}
 
-	t.driver.resources_lock.Lock()
-	defer t.driver.resources_lock.Unlock()
-
-	if _, ok := t.driver.resources[t.Resource.Identifier]; !ok {
+	res_file := filepath.Join(t.driver.cfg.WorkspacePath, t.Resource.Identifier)
+	if _, err := os.Stat(res_file); os.IsNotExist(err) {
 		out, _ := json.Marshal(map[string]any{})
 		return out, fmt.Errorf("TEST: Unable to snapshot unavailable resource '%s'", t.Resource.Identifier)
 	}

--- a/lib/drivers/vmx/driver.go
+++ b/lib/drivers/vmx/driver.go
@@ -257,7 +257,11 @@ func (d *Driver) Deallocate(res *types.Resource) error {
 
 	// Sometimes it's stuck, so try to stop a bit more than usual
 	if _, _, err := runAndLogRetry(3, 60*time.Second, d.cfg.VmrunPath, "stop", vmx_path); err != nil {
-		return log.Error("VMX: Unable to deallocate VM:", vmx_path, err)
+		log.Warn("VMX: Unable to soft stop the VM:", vmx_path, err)
+		// Ok, it doesn't want to stop, so stopping it hard
+		if _, _, err := runAndLogRetry(3, 60*time.Second, d.cfg.VmrunPath, "stop", vmx_path, "hard"); err != nil {
+			return log.Error("VMX: Unable to deallocate VM:", vmx_path, err)
+		}
 	}
 
 	// Delete VM

--- a/tests/allocate_multidefinition_label_test.go
+++ b/tests/allocate_multidefinition_label_test.go
@@ -41,7 +41,7 @@ drivers:
       ram_limit: 8`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/application_task_notexisting_fail_test.go
+++ b/tests/application_task_notexisting_fail_test.go
@@ -38,7 +38,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/application_task_snapshot_by_user_test.go
+++ b/tests/application_task_snapshot_by_user_test.go
@@ -38,7 +38,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/cant_allocate_too_big_label_test.go
+++ b/tests/cant_allocate_too_big_label_test.go
@@ -45,7 +45,7 @@ drivers:
       ram_limit: 8`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/default_lifetime_timeout_test.go
+++ b/tests/default_lifetime_timeout_test.go
@@ -39,7 +39,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/generated_uids_prefix_is_node_prefix_test.go
+++ b/tests/generated_uids_prefix_is_node_prefix_test.go
@@ -44,7 +44,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/label_find_filter_sql_injection_test.go
+++ b/tests/label_find_filter_sql_injection_test.go
@@ -41,7 +41,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/label_lifetime_timeout_test.go
+++ b/tests/label_lifetime_timeout_test.go
@@ -38,7 +38,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/label_overrides_default_lifetime_timeout_test.go
+++ b/tests/label_overrides_default_lifetime_timeout_test.go
@@ -39,7 +39,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/simple_app_create_destroy_test.go
+++ b/tests/simple_app_create_destroy_test.go
@@ -41,7 +41,7 @@ drivers:
   - name: test`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {

--- a/tests/three_apps_with_limit_test.go
+++ b/tests/three_apps_with_limit_test.go
@@ -44,7 +44,7 @@ drivers:
       ram_limit: 8`)
 
 	t.Cleanup(func() {
-		afi.Cleanup()
+		afi.Cleanup(t)
 	})
 
 	defer func() {


### PR DESCRIPTION
* BUGFIX: The changes about node resources monitoring and drivers placement messed up the node restart procedure if there was allocated resources, so fixed it and added integration test to fight the potential regression.
* BUGFIX: Fixed the issue with not stopping VMX VM's if they don't want to do that through soft procedure.

## Related Issue

caused by: #37

## How Has This Been Tested?

Automatically

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

