### PR TITLE
In dash interp `jobs -r` is not supported, so cutting it off

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -69,8 +69,11 @@ fi
 # Run parallel builds but no more than limit (gox doesn't support all the os/archs we need)
 pwait() {
     # Note: Dash really don't like jobs to be executed in a pipe or in other shell, soooo...
-    # Using "-p" to show only PIDs (because it could be multiline) and "-r" to show only running jobs
-    while jobs -pr > /tmp/jobs_list.tmp; do
+    # Using "jobs -p" to show only PIDs (because it could be multiline)
+    # Unfortunately "jobs -r" is not supported in dash, not a big problem with sleep for 1 sec
+    while jobs -p > /tmp/jobs_list.tmp; do
+        # Cleanup jobs list, otherwise "jobs -p" will stay the same forever
+        jobs > /dev/null 2>&1
         [ $(cat /tmp/jobs_list.tmp | wc -l) -ge $1 ] || break
         sleep 1
     done


### PR DESCRIPTION
Not important small fix, because `dash` doesn't really like jobs -r. Also if we will use only `-p` - it will display the same pid's even when they are completed.

## Related Issue

None

## Motivation and Context

Fun for sure

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

