### PR TITLE
Added pprof into the node API to debug memory leaks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All the files for now
+* @sparshev

--- a/README.md
+++ b/README.md
@@ -189,12 +189,29 @@ The election process:
 
 Simplify the cluster management, for example adding labels or check the status [#8](https://github.com/adobe/aquarium-fish/issues/8).
 
-## Integration tests
+## Development
+
+Is relatively easy - you change logic, you run `./build.sh` to create a binary, testing it and send
+the PR when you think it's perfect enough. That will be great if you can ask in the discussions or
+create an issue on GitHub to align with the current direction and the plans.
+
+### Integration tests
 
 To verify that everything works as expected you can run integration tests like that:
 ```sh
 $ FISH_PATH=$PWD/aquarium-fish.darwin_amd64 go test -v -failfast -parallel 4 ./tests/...
 ```
+
+### Profiling
+
+Is available through pprof like that:
+```
+$ go tool pprof 'https+insecure://<USER>:<TOKEN>@localhost:8001/api/v1/node/this/profiling/heap'
+$ curl -ku "<USER>:<TOKEN>" 'https://localhost:8001/api/v1/node/this/prof:w
+iling/?debug=1'
+```
+
+Or you can open https://localhost:8001/api/v1/node/this/profiling/ in browser to see the index.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ $ FISH_PATH=$PWD/aquarium-fish.darwin_amd64 go test -v -failfast -parallel 4 ./t
 Is available through pprof like that:
 ```
 $ go tool pprof 'https+insecure://<USER>:<TOKEN>@localhost:8001/api/v1/node/this/profiling/heap'
-$ curl -ku "<USER>:<TOKEN>" 'https://localhost:8001/api/v1/node/this/prof:w
-iling/?debug=1'
+$ curl -ku "<USER>:<TOKEN>" 'https://localhost:8001/api/v1/node/this/profiling/?debug=1'
 ```
 
 Or you can open https://localhost:8001/api/v1/node/this/profiling/ in browser to see the index.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -682,8 +682,8 @@ paths:
         - basic_auth: []
 
   # This /profiling/ endpoint is separate from the /profiling/{handler} because `required: false`
-  # behaved as expected. Since it is not, /profiling/ will route to a separate method that just
-  # calls the /profiling/{handler} endpoint with the empty string
+  # did not behaved as expected. Since it is not, /profiling/ will route to a separate method that
+  # just calls the /profiling/{handler} endpoint with the empty string
   /api/v1/node/this/profiling/:
     get:
       summary: Shows pprof index page

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -681,6 +681,52 @@ paths:
       security:
         - basic_auth: []
 
+  # In theory not needed if `required: false` work in the next API call, but it doesn't
+  /api/v1/node/this/profiling/:
+    get:
+      summary: Shows pprof index page
+      description:
+        Shows debug information about heap, goroutines, symbols etc. Very helpful in figuring out
+        the memory issues and to understand the internals of the Fish Node execution.
+      operationId: NodeThisProfilingIndexGet
+      tags:
+        - Node
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Bad parameter or conditions
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+      security:
+        - basic_auth: []
+
+  /api/v1/node/this/profiling/{handler}:
+    get:
+      summary: Gives profiling data from pprof
+      description:
+        Shows debug information about heap, goroutines, symbols etc. Very helpful in figuring out
+        the memory issues and to understand the internals of the Fish Node execution.
+      operationId: NodeThisProfilingGet
+      tags:
+        - Node
+      parameters:
+        - name: handler
+          in: path
+          description: Which pprof handler to use. If empty - will show index
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Bad parameter or conditions
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+      security:
+        - basic_auth: []
+
   /api/v1/location/:
     get:
       summary: Get list of locations

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -681,7 +681,9 @@ paths:
       security:
         - basic_auth: []
 
-  # In theory not needed if `required: false` work in the next API call, but it doesn't
+  # This /profiling/ endpoint is separate from the /profiling/{handler} because `required: false`
+  # behaved as expected. Since it is not, /profiling/ will route to a separate method that just
+  # calls the /profiling/{handler} endpoint with the empty string
   /api/v1/node/this/profiling/:
     get:
       summary: Shows pprof index page

--- a/lib/openapi/api/api_v1.go
+++ b/lib/openapi/api/api_v1.go
@@ -489,8 +489,9 @@ func (e *Processor) NodeThisProfilingIndexGet(c echo.Context) error {
 func (e *Processor) NodeThisProfilingGet(c echo.Context, handler string) error {
 	user := c.Get("user")
 	if user.(*types.User).Name != "admin" {
-		c.JSON(http.StatusBadRequest, H{"message": fmt.Sprintf("Only 'admin' can see profiling info")})
-		return fmt.Errorf("Only 'admin' user can see profiling info")
+		message := "Only 'admin' can see profiling info"
+		c.JSON(http.StatusBadRequest, H{"message": message})
+		return fmt.Errorf(message)
 	}
 
 	switch handler {
@@ -509,7 +510,9 @@ func (e *Processor) NodeThisProfilingGet(c echo.Context, handler string) error {
 	case "trace":
 		pprof.Trace(c.Response(), c.Request())
 	default:
-		return fmt.Errorf("Unable to find requested profiling handler")
+		message := "Unable to find requested profiling handler"
+		c.JSON(http.StatusNotFound, H{"message": message})
+		return fmt.Errorf(message)
 	}
 
 	return nil


### PR DESCRIPTION
Integrated pprof to get profiling of the running Fish node - really helpful to understand what's inside causing bugs.

Tried to implement through `pperf.Index()`, but it's processing only handlers without the advanced calls like trace & profile... So implementation is a bit bigger then could be...

## Related Issue

#64 

## Motivation and Context

In order to debug OOM's

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

