### PR TITLE
Add patch version number in go.mod (X.Y => X.Y.Z)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adobe/aquarium-fish
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/alessio/shellescape v1.4.1


### PR DESCRIPTION
> Before Go 1.21, the initial release of a Go toolchain was
> version 1.N, not 1.N.0, so for N < 21, the ordering is
> adjusted to place 1.N after the release candidates.
>
> https://go.dev/doc/toolchain#version

Go changed its versioning scheme in 1.21 from `<major>.<minor>` to `<major>.<minor>.<patch>`.  CodeQL analysis flags this stating the lack of a patch number "may cause some `go` commands to fail."

## Motivation and Context

CodeQL Analysis warns that some tooling may break without the patch number.

## How Has This Been Tested?

It has not been; other than CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

