### PR TITLE
Fix for hardcoded image wait timeout on TaskImage

### DIFF
--- a/lib/drivers/aws/config.go
+++ b/lib/drivers/aws/config.go
@@ -39,7 +39,8 @@ type Config struct {
 	DedicatedPool map[string]DedicatedPoolRecord `json:"dedicated_pool"`
 
 	// Various options to not hardcode the important numbers
-	ImageCreateWait util.Duration `json:"image_create_wait"` // Maximum wait time for image availability (create/copy), default: 2h
+	SnapshotCreateWait util.Duration `json:"snapshot_create_wait"` // Maximum wait time for snapshot availability (create), default: 2h
+	ImageCreateWait    util.Duration `json:"image_create_wait"`    // Maximum wait time for image availability (create/copy), default: 2h
 }
 
 // Stores the configuration of AWS dedicated pool of particular type to manage
@@ -166,8 +167,11 @@ func (c *Config) Validate() (err error) {
 	}
 
 	// Set defaults for other variables
+	if c.SnapshotCreateWait <= 0 {
+		c.SnapshotCreateWait = util.Duration(120 * time.Minute) // 60min is not enough for windows snapshots
+	}
 	if c.ImageCreateWait <= 0 {
-		c.ImageCreateWait = util.Duration(120 * time.Minute) // 60 is not enough for windows image
+		c.ImageCreateWait = util.Duration(120 * time.Minute) // 60min is not enough for windows image
 	}
 
 	return nil

--- a/lib/drivers/aws/config.go
+++ b/lib/drivers/aws/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// Manage the AWS dedicated hosts to keep them busy and deallocate when not needed
 	// Key of the map is name of the pool - will be used for identification of the pool
 	DedicatedPool map[string]DedicatedPoolRecord `json:"dedicated_pool"`
+
+	// Various options to not hardcode the important numbers
+	ImageCreateWait util.Duration `json:"image_create_wait"` // Maximum wait time for image availability (create/copy), default: 2h
 }
 
 // Stores the configuration of AWS dedicated pool of particular type to manage
@@ -160,6 +163,11 @@ func (c *Config) Validate() (err error) {
 		if pool.ScrubbingDelay > 0 && time.Duration(pool.ScrubbingDelay) < 1*time.Minute {
 			return fmt.Errorf("AWS: Scrubbing delay of pool %q is less then 1 minute: %v", name, pool.ScrubbingDelay)
 		}
+	}
+
+	// Set defaults for other variables
+	if c.ImageCreateWait <= 0 {
+		c.ImageCreateWait = util.Duration(120 * time.Minute) // 60 is not enough for windows image
 	}
 
 	return nil

--- a/lib/drivers/aws/task_image.go
+++ b/lib/drivers/aws/task_image.go
@@ -267,7 +267,7 @@ func (t *TaskImage) Execute() (result []byte, err error) {
 		}
 		if err = sw.Wait(context.TODO(), &wait_input, max_wait); err != nil {
 			// Do not fail hard here - we still need to remove the tmp image
-			log.Errorf("AWS: TaskIamge %s: Error during wait for re-encrypted image availability: %s %s, %v", t.ApplicationTask.UID, image_name, aws.ToString(resp.ImageId), err)
+			log.Errorf("AWS: TaskImage %s: Error during wait for re-encrypted image availability: %s %s, %v", t.ApplicationTask.UID, image_name, aws.ToString(resp.ImageId), err)
 		}
 
 		// Delete the temp image & associated snapshots

--- a/lib/drivers/aws/task_image.go
+++ b/lib/drivers/aws/task_image.go
@@ -54,20 +54,20 @@ func (t *TaskImage) SetInfo(task *types.ApplicationTask, def *types.LabelDefinit
 // Image could be executed during ALLOCATED & DEALLOCATE ApplicationStatus
 func (t *TaskImage) Execute() (result []byte, err error) {
 	if t.ApplicationTask == nil {
-		return []byte(`{"error":"internal: invalid application task"}`), log.Error("AWS: Invalid application task:", t.ApplicationTask)
+		return []byte(`{"error":"internal: invalid application task"}`), log.Error("AWS: TaskImage: Invalid application task:", t.ApplicationTask)
 	}
 	if t.LabelDefinition == nil {
-		return []byte(`{"error":"internal: invalid label definition"}`), log.Error("TEST: Invalid label definition:", t.LabelDefinition)
+		return []byte(`{"error":"internal: invalid label definition"}`), log.Errorf("AWS: Invalid label definition: %v", t.LabelDefinition)
 	}
 	if t.Resource == nil || t.Resource.Identifier == "" {
-		return []byte(`{"error":"internal: invalid resource"}`), log.Error("AWS: Invalid resource:", t.Resource)
+		return []byte(`{"error":"internal: invalid resource"}`), log.Errorf("AWS: Invalid resource: %v", t.Resource)
 	}
 	log.Infof("AWS: TaskImage %s: Creating image for Application %s", t.ApplicationTask.UID, t.ApplicationTask.ApplicationUID)
 	conn := t.driver.newEC2Conn()
 
 	var opts Options
 	if err := opts.Apply(t.LabelDefinition.Options); err != nil {
-		log.Error("AWS: Unable to apply options:", err)
+		log.Errorf("AWS: TaskImage %s: Unable to apply options: %v", t.ApplicationTask.UID, err)
 		return []byte(`{"error":"internal: unable to apply label definition options"}`), log.Errorf("AWS: Unable to apply label definition options: %w", err)
 	}
 
@@ -81,11 +81,11 @@ func (t *TaskImage) Execute() (result []byte, err error) {
 		result, err := conn.StopInstances(context.TODO(), &input)
 		if err != nil {
 			// Do not fail hard here - it's still possible to take image of the instance
-			log.Error("AWS: Error during stopping the instance:", t.Resource.Identifier, err)
+			log.Errorf("AWS: TaskImage %s: Error during stopping the instance %s: %v", t.ApplicationTask.UID, t.Resource.Identifier, err)
 		}
 		if len(result.StoppingInstances) < 1 || *result.StoppingInstances[0].InstanceId != t.Resource.Identifier {
 			// Do not fail hard here - it's still possible to take image of the instance
-			log.Error("AWS: Wrong instance id result during stopping:", t.Resource.Identifier)
+			log.Errorf("AWS: TaskImage %s: Wrong instance id result during stopping: %s", t.ApplicationTask.UID, t.Resource.Identifier)
 		}
 	}
 
@@ -103,7 +103,7 @@ func (t *TaskImage) Execute() (result []byte, err error) {
 		}
 		describe_resp, err := conn.DescribeInstanceAttribute(context.TODO(), &describe_input)
 		if err != nil {
-			return []byte{}, log.Errorf("AWS: Unable to request the instance RootDeviceName attribute %s: %v", t.Resource.Identifier, err)
+			return []byte(`{"error":"internal: failed to request instance root device"}`), log.Errorf("AWS: Unable to request the instance RootDeviceName attribute %s: %v", t.Resource.Identifier, err)
 		}
 		root_device := aws.ToString(describe_resp.RootDeviceName.Value)
 
@@ -114,7 +114,7 @@ func (t *TaskImage) Execute() (result []byte, err error) {
 		}
 		describe_resp, err = conn.DescribeInstanceAttribute(context.TODO(), &describe_input)
 		if err != nil {
-			return []byte{}, log.Errorf("AWS: Unable to request the instance BlockDeviceMapping attribute %s: %v", t.Resource.Identifier, err)
+			return []byte(`{"error":"internal: failed to request instance block device mapping"}`), log.Errorf("AWS: Unable to request the instance BlockDeviceMapping attribute %s: %v", t.Resource.Identifier, err)
 		}
 
 		// Filter the block devices in the image if we don't need full one
@@ -128,14 +128,14 @@ func (t *TaskImage) Execute() (result []byte, err error) {
 			} else {
 				log.Debugf("AWS: TaskImage %s: Only root disk will be used to create image: %s", t.ApplicationTask.UID, root_device)
 				if dev.Ebs == nil {
-					return []byte{}, log.Errorf("AWS: Root disk doesn't have EBS configuration")
+					return []byte(`{"error":"internal: root disk of instance doesn't have EBS config"}`), log.Errorf("AWS: Root disk doesn't have EBS configuration")
 				}
 				params := ec2.DescribeVolumesInput{
 					VolumeIds: []string{aws.ToString(dev.Ebs.VolumeId)},
 				}
 				vol_resp, err := conn.DescribeVolumes(context.TODO(), &params)
 				if err != nil || len(vol_resp.Volumes) < 1 {
-					return []byte{}, log.Errorf("AWS: Unable to request the instance root volume info %s: %v", aws.ToString(dev.Ebs.VolumeId), err)
+					return []byte(`{"error":"internal: failed to request instance volume info config"}`), log.Errorf("AWS: Unable to request the instance root volume info %s: %v", aws.ToString(dev.Ebs.VolumeId), err)
 				}
 				vol_info := vol_resp.Volumes[0]
 				mapping.Ebs = &ec2_types.EbsBlockDevice{
@@ -202,72 +202,78 @@ func (t *TaskImage) Execute() (result []byte, err error) {
 		}
 		if err := sw.Wait(context.TODO(), &wait_input, max_wait); err != nil {
 			// Do not fail hard here - it's still possible to create image of the instance
-			log.Error("AWS: Error during wait for instance stop:", t.Resource.Identifier, err)
+			log.Errorf("AWS: TaskImage %s: Error during wait for instance %s stop: %v", t.ApplicationTask.UID, t.Resource.Identifier, err)
 		}
 	}
 	log.Debugf("AWS: TaskImage %s: Creating image with name %q...", t.ApplicationTask.UID, aws.ToString(input.Name))
 	resp, err := conn.CreateImage(context.TODO(), &input)
 	if err != nil {
-		return []byte{}, log.Errorf("AWS: Unable to create image from instance %s: %v", t.Resource.Identifier, err)
+		return []byte(`{"error":"internal: failed to create image from instance"}`), log.Errorf("AWS: Unable to create image from instance %s: %v", t.Resource.Identifier, err)
 	}
 	if resp.ImageId == nil {
-		return []byte{}, log.Errorf("AWS: No image was created from instance %s", t.Resource.Identifier)
+		return []byte(`{"error":"internal: no image was created from instance"}`), log.Errorf("AWS: No image was created from instance %s", t.Resource.Identifier)
 	}
 
 	image_id := aws.ToString(resp.ImageId)
 	log.Infof("AWS: TaskImage %s: Created image %q with id %q...", t.ApplicationTask.UID, aws.ToString(input.Name), image_id)
 
+	// Wait for the image to be completed, otherwise if we will start a copy - it will fail...
+	log.Infof("AWS: TaskImage %s: Wait for image %s %q availability...", t.ApplicationTask.UID, image_id, aws.ToString(input.Name))
+	sw := ec2.NewImageAvailableWaiter(conn)
+	max_wait := time.Duration(t.driver.cfg.ImageCreateWait)
+	wait_input := ec2.DescribeImagesInput{
+		ImageIds: []string{
+			image_id,
+		},
+	}
+	if err = sw.Wait(context.TODO(), &wait_input, max_wait); err != nil {
+		// Need to make sure tmp image will be removed, while target image could stay and complete
+		if opts.TaskImageEncryptKey != "" {
+			log.Debugf("AWS: TaskImage %s: Cleanup the temp image %q", t.ApplicationTask.UID, image_id)
+			if err := t.driver.deleteImage(conn, image_id); err != nil {
+				log.Errorf("AWS: TaskImage %s: Unable to cleanup the temp image %s: %v", t.ApplicationTask.UID, t.Resource.Identifier, err)
+			}
+		}
+		return []byte(`{"error":"internal: timeout on await for the image availability"}`), log.Error("AWS: Error during wait for the image availability:", image_id, aws.ToString(input.Name), err)
+	}
+
 	// If TaskImageEncryptKey is set - we need to copy the image with enabled encryption and delete the temp one
 	if opts.TaskImageEncryptKey != "" {
-		// Wait for the tmp image to be completed, otherwise if we will start a copy - it will fail...
-		log.Infof("AWS: TaskImage %s: Wait for image %s %q availability...", t.ApplicationTask.UID, image_id, aws.ToString(input.Name))
+		copy_input := ec2.CopyImageInput{
+			Name:          aws.String(image_name),
+			Description:   input.Description,
+			SourceImageId: resp.ImageId,
+			SourceRegion:  aws.String(t.driver.cfg.Region),
+			CopyImageTags: aws.Bool(true),
+			Encrypted:     aws.Bool(true),
+			KmsKeyId:      aws.String(opts.TaskImageEncryptKey),
+		}
+		log.Infof("AWS: TaskImage %s: Re-encrypting tmp image to final image %q", t.ApplicationTask.UID, aws.ToString(copy_input.Name))
+		resp, err := conn.CopyImage(context.TODO(), &copy_input)
+		if err != nil {
+			return []byte(`{"error":"internal: failed to copy image"}`), log.Errorf("AWS: Unable to copy image from tmp image %s: %v", aws.ToString(resp.ImageId), err)
+		}
+		if resp.ImageId == nil {
+			return []byte(`{"error":"internal: no image was copied"}`), log.Errorf("AWS: No image was copied from tmp image %s", aws.ToString(resp.ImageId))
+		}
+		// Wait for the image to be completed, otherwise if we will delete the temp one right away it will fail...
+		log.Infof("AWS: TaskImage %s: Wait for re-encrypted image %s %q availability...", t.ApplicationTask.UID, aws.ToString(resp.ImageId), image_name)
 		sw := ec2.NewImageAvailableWaiter(conn)
-		max_wait := 60 * time.Minute
+		max_wait := time.Duration(t.driver.cfg.ImageCreateWait)
 		wait_input := ec2.DescribeImagesInput{
 			ImageIds: []string{
-				image_id,
+				aws.ToString(resp.ImageId),
 			},
 		}
-		if err := sw.Wait(context.TODO(), &wait_input, max_wait); err != nil {
+		if err = sw.Wait(context.TODO(), &wait_input, max_wait); err != nil {
 			// Do not fail hard here - we still need to remove the tmp image
-			log.Error("AWS: Error during wait for image availability:", image_id, err)
-		} else {
-			copy_input := ec2.CopyImageInput{
-				Name:          aws.String(image_name),
-				Description:   input.Description,
-				SourceImageId: resp.ImageId,
-				SourceRegion:  aws.String(t.driver.cfg.Region),
-				CopyImageTags: aws.Bool(true),
-				Encrypted:     aws.Bool(true),
-				KmsKeyId:      aws.String(opts.TaskImageEncryptKey),
-			}
-			log.Infof("AWS: TaskImage %s: Re-encrypting tmp image to final image %q", t.ApplicationTask.UID, aws.ToString(copy_input.Name))
-			resp, err := conn.CopyImage(context.TODO(), &copy_input)
-			if err != nil {
-				return []byte{}, log.Errorf("AWS: Unable to copy image from tmp image %s: %v", aws.ToString(resp.ImageId), err)
-			}
-			if resp.ImageId == nil {
-				return []byte{}, log.Errorf("AWS: No image was copied from tmp image %s", aws.ToString(resp.ImageId))
-			}
-			// Wait for the image to be completed, otherwise if we will delete the temp one right away it will fail...
-			log.Infof("AWS: TaskImage %s: Wait for re-encrypted image %s %q availability...", t.ApplicationTask.UID, aws.ToString(resp.ImageId), image_name)
-			sw := ec2.NewImageAvailableWaiter(conn)
-			max_wait := 60 * time.Minute
-			wait_input := ec2.DescribeImagesInput{
-				ImageIds: []string{
-					aws.ToString(resp.ImageId),
-				},
-			}
-			if err := sw.Wait(context.TODO(), &wait_input, max_wait); err != nil {
-				// Do not fail hard here - we still need to remove the tmp image
-				log.Error("AWS: Error during wait for re-encrypted image availability:", aws.ToString(resp.ImageId), err)
-			}
+			log.Errorf("AWS: TaskIamge %s: Error during wait for re-encrypted image availability: %s %s, %v", t.ApplicationTask.UID, image_name, aws.ToString(resp.ImageId), err)
 		}
 
 		// Delete the temp image & associated snapshots
 		log.Debugf("AWS: TaskImage %s: Deleting the temp image %q", t.ApplicationTask.UID, image_id)
 		if err = t.driver.deleteImage(conn, image_id); err != nil {
-			return []byte{}, log.Errorf("AWS: Unable to create image from instance %s: %v", t.Resource.Identifier, err)
+			return []byte(`{"error":"internal: unable to delete the tmp image"}`), log.Errorf("AWS: Unable to delete the temp image %s: %v", image_id, err)
 		}
 
 		image_id = aws.ToString(resp.ImageId)

--- a/lib/drivers/aws/util.go
+++ b/lib/drivers/aws/util.go
@@ -232,7 +232,7 @@ func (d *Driver) getImageId(conn *ec2.Client, id_name string) (string, error) {
 	p := ec2.NewDescribeImagesPaginator(conn, &req)
 	resp, err := conn.DescribeImages(context.TODO(), &req)
 	if err != nil || len(resp.Images) == 0 {
-		return "", fmt.Errorf("AWS: Unable to locate image with specified name: %v", err)
+		return "", fmt.Errorf("AWS: Unable to locate image with specified name: %s, err: %v", id_name, err)
 	}
 	id_name = aws.ToString(resp.Images[0].ImageId)
 

--- a/lib/fish/fish.go
+++ b/lib/fish/fish.go
@@ -606,7 +606,7 @@ func (f *Fish) executeApplication(vote types.Vote) error {
 		// Allocate the resource
 		if app_state.Status == types.ApplicationStatusELECTED {
 			// Run the allocation
-			log.Info("Fish: Allocate the resource using the driver", driver.Name())
+			log.Infof("Fish: Allocate the Application %s resource using driver: %s", app.UID, driver.Name())
 			drv_res, err := driver.Allocate(label_def, metadata)
 			if err != nil {
 				log.Error("Fish: Unable to allocate resource for the Application:", app.UID, err)
@@ -627,6 +627,7 @@ func (f *Fish) executeApplication(vote types.Vote) error {
 				app_state = &types.ApplicationState{ApplicationUID: app.UID, Status: types.ApplicationStatusALLOCATED,
 					Description: fmt.Sprint("Driver allocated the resource"),
 				}
+				log.Infof("Fish: Allocated Resource %q for the Application %s", app.UID, res.Identifier)
 			}
 			f.ApplicationStateCreate(app_state)
 		}
@@ -684,7 +685,7 @@ func (f *Fish) executeApplication(vote types.Vote) error {
 			f.executeApplicationTasks(driver, &label_def, res, app_state.Status)
 
 			if app_state.Status == types.ApplicationStatusDEALLOCATE || app_state.Status == types.ApplicationStatusRECALLED {
-				log.Info("Fish: Running Deallocate of the Application:", app.UID)
+				log.Info("Fish: Running Deallocate of the Application and Resource:", app.UID, res.Identifier)
 				// Deallocating and destroy the resource
 				if err := driver.Deallocate(res); err != nil {
 					log.Errorf("Fish: Unable to deallocate the Resource of Application: %s (try: %d): %v", app.UID, deallocate_retry, err)


### PR DESCRIPTION
Found TaskImage for windows images generates successful output even for timeout on image availability waiting - so fixed that and added much more logging to easily figure out what's happening and where.

## Related Issue

#74

## Motivation and Context

It should be just better

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

