### PR TITLE
Fixed issue with publish benchmark results to gh-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           INPUT_PRUNE_COUNT: 30
           INPUT_GO_TEST_FLAGS: "-run=^# -cpu 1,2 -benchmem"
           INPUT_CHECKS_CONFIG: gobenchdata-checks.yml
-          GITHUB_TOKEN: '${{ secrets.ACCESS_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Benchmarks PR
         run: go run go.bobheadxi.dev/gobenchdata@v1 action
@@ -87,7 +87,6 @@ jobs:
           INPUT_PRUNE_COUNT: 30
           INPUT_GO_TEST_FLAGS: "-run=^# -cpu 1,2 -benchmem"
           INPUT_CHECKS_CONFIG: gobenchdata-checks.yml
-          GITHUB_TOKEN: '${{ secrets.ACCESS_TOKEN }}'
 
       - name: Integration Tests
         run: |


### PR DESCRIPTION
Incorrect token usage in workflow prevented to publish.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

CI should work properly

## How Has This Been Tested?

Automatic

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

