### PR TITLE
Allow user to change its password

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -49,9 +49,9 @@ paths:
       security:
         - basic_auth: []
     post:
-      summary: Create new User
-      description: Creates & return the created User, it will generate password if not provided
-      operationId: UserCreatePost
+      summary: Create or update User
+      description: Creates or updates & return the User, it will generate password if not provided
+      operationId: UserCreateUpdatePost
       tags:
         - User
       parameters: []
@@ -1250,7 +1250,6 @@ components:
         - created_at
         - updated_at
         - password
-        - hash
       properties:
         name:
           $ref: '#/components/schemas/UserName'


### PR DESCRIPTION
The change allows admin and user himself to change password when needed. Admin can change the other users passwords and user can change it's own password now. Before admin was able to recreate user, but for admin there was no way to change auto-generated password.

## Motivation and Context

Needed for smooth migration

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

