### PR TITLE
AWS: OOM in Dedicated pool management subroutine - New Year Jan bug hotfix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,8 @@ BINARY_NAME="aquarium-fish-$git_version"
 
 echo
 echo "--- RUN UNIT TESTS ---"
-go test -ldflags="$version_flags" -v ./lib/...
+# Unit tests should not consume more then 5 sec per run - for that we have integration tests
+go test -timeout=5s -ldflags="$version_flags" -v ./lib/...
 
 echo
 echo "--- BUILD ${BINARY_NAME} ($MAXJOBS in parallel) ---"

--- a/lib/drivers/aws/util.go
+++ b/lib/drivers/aws/util.go
@@ -717,7 +717,7 @@ func (d *Driver) deleteImage(conn *ec2.Client, id string) (err error) {
 func awsLastYearFilterValues(till time.Time) (out []string) {
 	date := till
 	// Iterating over months to cover the last year
-	for date.Year() == till.Year() || date.Month() >= till.Month() {
+	for date.Year() == till.Year() || date.Month() > till.Month() {
 		out = append(out, date.Format("2006-01-*"))
 		date = date.AddDate(0, -1, 0)
 	}

--- a/lib/drivers/aws/util_test.go
+++ b/lib/drivers/aws/util_test.go
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Make sure there is no more issues in a simple logic of awsLastYearFilterValues like the Jan bug
+func Test_awsLastYearFilterValues(t *testing.T) {
+	// Next 100 years should be enough to be sure
+	imagesTill := time.Now()
+	endyear := imagesTill.AddDate(100, 0, 0).Year()
+	for imagesTill.Year() < endyear {
+		curryear := imagesTill.Year()
+		t.Run(fmt.Sprintf("Testing year `%d`", curryear), func(t *testing.T) {
+			for imagesTill.Year() == curryear {
+				imagesTill = imagesTill.AddDate(0, 1, 0)
+				out := awsLastYearFilterValues(imagesTill)
+				if len(out) != 12 {
+					t.Fatalf("awsLastYearFilterValues(`%s`) = `%s` (len = %d); want: 12 values", imagesTill.Format("2006-01"), out, len(out))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This nasty bug appears only in January of each year and affects the Fish configurations with enabled dedicated pool management. It causes OOM due to incorrect handling of 1 month of the year and looks like that in pprof when the schedule runs dedicated pool refresh:
```
      flat  flat%   sum%        cum   cum%
  941.38MB 51.60% 51.60%  1757.39MB 96.33%  github.com/adobe/aquarium-fish/lib/drivers/aws.awsLastYearFilterValues
  816.01MB 44.73% 96.33%   816.01MB 44.73%  time.Time.Format
      64MB  3.51% 99.83%       64MB  3.51%  golang.org/x/crypto/argon2.initBlocks
         0     0% 99.83%       64MB  3.51%  github.com/adobe/aquarium-fish/lib/crypt.(*Hash).IsEqual
         0     0% 99.83%  1757.39MB 96.33%  github.com/adobe/aquarium-fish/lib/drivers/aws.(*Driver).getImageIDByType
         0     0% 99.83%  1757.39MB 96.33%  github.com/adobe/aquarium-fish/lib/drivers/aws.(*Driver).triggerHostScrubbing
         0     0% 99.83%  1757.39MB 96.33%  github.com/adobe/aquarium-fish/lib/drivers/aws.(*dedicatedPoolWorker).backgroundProcess
         0     0% 99.83%  1757.39MB 96.33%  github.com/adobe/aquarium-fish/lib/drivers/aws.(*dedicatedPoolWorker).releaseHosts
         0     0% 99.83%       64MB  3.51%  github.com/adobe/aquarium-fish/lib/fish.(*Fish).UserAuth
         0     0% 99.83%       64MB  3.51%  github.com/adobe/aquarium-fish/lib/openapi/api.(*Processor).BasicAuth
```

## Motivation and Context

Prod was affected

## How Has This Been Tested?

Manually & automatically via unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

