### PR TITLE
AF-60 Support multiple zones for dedicated hosts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
-        uses: swaggerexpert/swagger-editor-validate@452076dc45d5d1f09dd55440c9bffc372de4da25  # Jul 29, 2024
+        uses: swaggerexpert/swagger-editor-validate@e8e51dbc8c18e87f96b082b18a6a7cbd3c44abd8  # v1.4.2, Dec 31 2024
         with:
           swagger-editor-url: http://localhost/
           definition-file: docs/openapi.yaml

--- a/docs/drivers/aws/aws_simulator/aws_dedicated_mac_pool_simulator.py
+++ b/docs/drivers/aws/aws_simulator/aws_dedicated_mac_pool_simulator.py
@@ -294,7 +294,7 @@ class Event:
         print("Hosts           h/mon:", " ".join(["{:>10.2f}".format(h) for h in Event.stat_hosts_hours_per_month]))
         print("Queue           h/mon:", " ".join(["{:>10.2f}".format(hs) for hs in Event.stat_queue_hours_per_month]))
         # Mean wait means - if the item got into queue - for how long it usually waits before get executed
-        print("Queue Mean wait s/mon:", " ".join(["{:>10.2f}".format((statistics.mean(ss)) if ss else 0.0) for ss in Event.stat_queue_mean_wait_mins_per_month]))
+        print("Queue Mean wait m/mon:", " ".join(["{:>10.2f}".format((statistics.mean(mm)) if mm else 0.0) for mm in Event.stat_queue_mean_wait_mins_per_month]))
 
     def __init__(self, start, fun, params):
         self.start = start

--- a/lib/drivers/aws/config.go
+++ b/lib/drivers/aws/config.go
@@ -48,9 +48,9 @@ type Config struct {
 // DedicatedPoolRecord stores the configuration of AWS dedicated pool of particular type to manage
 // aws ec2 allocate-hosts --availability-zone "us-west-2c" --auto-placement "on" --host-recovery "off" --host-maintenance "off" --quantity 1 --instance-type "mac2.metal"
 type DedicatedPoolRecord struct {
-	Type string `json:"type"` // Instance type handled by the dedicated hosts pool (example: "mac2.metal")
-	Zone string `json:"zone"` // Where to allocate the dedicated host (example: "us-west-2c")
-	Max  uint   `json:"max"`  // Maximum dedicated hosts to allocate (they sometimes can handle more than 1 capacity slot)
+	Type  string   `json:"type"`  // Instance type handled by the dedicated hosts pool (example: "mac2.metal")
+	Zones []string `json:"zones"` // Where to allocate the dedicated host (example: ["us-west-2a", "us-west-2c"])
+	Max   uint     `json:"max"`   // Maximum dedicated hosts to allocate (they sometimes can handle more than 1 capacity slot)
 
 	// Is a special optimization for the Mac dedicated hosts to send them in [scrubbing process] to
 	// save money when we can't release the host due to Apple's license of [24 hours] min limit.

--- a/lib/proxyssh/proxy.go
+++ b/lib/proxyssh/proxy.go
@@ -344,7 +344,7 @@ func (p *proxySSH) publicKeyCallback(incomingConn ssh.ConnMetadata, key ssh.Publ
 
 	ra, err := p.fish.ResourceAccessSingleUseKey(fishUser.Name, stringKey)
 	if err != nil {
-		log.Errorf("PROXYSSH: %s: Invalid access for user %q: %v", incomingConn.RemoteAddr(), user, err)
+		log.Errorf("PROXYSSH: %s: Invalid access for user %q: %v", incomingConn.RemoteAddr(), fishUser.Name, err)
 		return nil, fmt.Errorf("Invalid access")
 	}
 


### PR DESCRIPTION
Figured that dedicated host is attached to zone and can't be moved across, so in case we consumed all the dedicated hosts of type in specific zone - we need to switch to another one. So for now the logic is sequential, but maybe in the future will be needed to add different distribution policies to balance between the zones (will be complicated, because AWS gives no interfaces to check how much hosts left in the zone).

**WARNING:** Changes interface for dedicated hosts configuration: `zone` replaced with `zones`, which contain list of strings.

## Related Issue

#60 

## Motivation and Context

Ya know, for fun! (and actually needed to make our pool work correctly of course)

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

