### PR TITLE
AF-60 Fixed missed instance zone filtering when using dedicated pool

### DIFF
--- a/lib/drivers/aws/driver.go
+++ b/lib/drivers/aws/driver.go
@@ -289,7 +289,7 @@ func (d *Driver) Allocate(def types.LabelDefinition, metadata map[string]any) (*
 		MaxCount: aws.Int32(1),
 	}
 
-	netZone := ""
+	var netZone string
 	if opts.Pool != "" {
 		// Let's reserve or allocate the host for the new instance
 		p, ok := d.dedicatedPools[opts.Pool]
@@ -297,7 +297,7 @@ func (d *Driver) Allocate(def types.LabelDefinition, metadata map[string]any) (*
 			return nil, fmt.Errorf("AWS: %s: Unable to locate the dedicated pool: %s", iName, opts.Pool)
 		}
 
-		hostID := ""
+		var hostID string
 		if hostID, netZone = p.ReserveAllocateHost(opts.InstanceType); hostID == "" {
 			return nil, fmt.Errorf("AWS: %s: Unable to reserve host in dedicated pool %q", iName, opts.Pool)
 		}

--- a/tests/perf_max_requests_test.go
+++ b/tests/perf_max_requests_test.go
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	h "github.com/adobe/aquarium-fish/tests/helper"
+)
+
+// Benchmark to find the max amount of requests per second
+func Test_max_requests(t *testing.T) {
+	//t.Parallel()  - nope just one at a time
+	afi := h.NewAquariumFish(t, "node-1", `---
+node_location: test_loc
+cpu_limit: 2
+mem_target: "512MB"
+
+api_address: 127.0.0.1:0
+proxy_ssh_address: 127.0.0.1:0
+
+drivers:
+  - name: test
+    cfg:
+      cpu_limit: 1
+      ram_limit: 2`)
+
+	t.Cleanup(func() {
+		afi.Cleanup(t)
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: tr,
+	}
+
+	var label types.Label
+	apitest.New().
+		EnableNetworking(cli).
+		Post(afi.APIAddress("api/v1/label/")).
+		JSON(`{"name":"test-label", "version":1, "definitions": [
+			{"driver":"test", "resources":{"cpu":2,"ram":4}}
+		]}`).
+		BasicAuth("admin", afi.AdminToken()).
+		Expect(t).
+		Status(http.StatusOK).
+		End().
+		JSON(&label)
+
+	if label.UID == uuid.Nil {
+		t.Fatalf("Label UID is incorrect: %v", label.UID)
+	}
+
+	var app types.Application
+	apitest.New().
+		EnableNetworking(cli).
+		Post(afi.APIAddress("api/v1/application/")).
+		JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+		BasicAuth("admin", afi.AdminToken()).
+		Expect(t).
+		Status(http.StatusOK).
+		End().
+		JSON(&app)
+
+	if app.UID == uuid.Nil {
+		t.Errorf("Application UID is incorrect: %v", app.UID)
+	}
+
+	// Here all the apps are in the queue, so let's request something with a small timeout
+	var appState types.ApplicationState
+	apitest.New().
+		EnableNetworking(cli).
+		Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/state")).
+		BasicAuth("admin", afi.AdminToken()).
+		Expect(t).
+		Status(http.StatusOK).
+		End().
+		JSON(&appState)
+
+	if appState.Status != types.ApplicationStatusNEW {
+		t.Fatalf("Application Status is incorrect: %v", appState.Status)
+	}
+
+	// Running periodic requests to test what's the delay will be
+	wg := &sync.WaitGroup{}
+	reachedLimit := false
+	workerFunc := func(t *testing.T, wg *sync.WaitGroup, afi *h.AFInstance, cli *http.Client) {
+		defer wg.Done()
+
+		var appState types.ApplicationState
+		for !reachedLimit {
+			start := time.Now()
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(t).
+				Status(http.StatusOK).
+				End().
+				JSON(&appState)
+
+			elapsed := time.Since(start).Milliseconds()
+			t.Logf("Request delay: %dms", elapsed)
+			if elapsed > 5000 {
+				reachedLimit = true
+			}
+		}
+		t.Logf("Client thread completed")
+	}
+	counter := 0
+	for !reachedLimit {
+		// Graduadely increase the amount of parallel threads
+		wg.Add(1)
+		go workerFunc(t, wg, afi, cli)
+		counter += 1
+		t.Logf("Client threads: %d", counter)
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Logf("Completed, waiting for stop: %d", counter)
+	wg.Wait()
+}


### PR DESCRIPTION
Bugfix: Figured it's not enough to just locate the dedicated host in the pool - we need to ensure that subnet is picked up correctly for the instance. Otherwise we seeing how instances are failed to be allocated because of mismatch of the picked instance subnet and dedicated host zone.

## Related Issue

#60 

## Motivation and Context

All bugs need to be out

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

