### PR TITLE
AF-98 Added cache to AWS availability and new test to check restart app cleanup

### DIFF
--- a/lib/drivers/aws/driver.go
+++ b/lib/drivers/aws/driver.go
@@ -63,6 +63,11 @@ type Driver struct {
 	quotasMutex      sync.Mutex
 	quotasNextUpdate time.Time
 
+	// Stores cache per type of the instance needed
+	typeCache        map[string]int64
+	typeCacheUpdated map[string]time.Time
+	typeCacheMutex   sync.Mutex
+
 	dedicatedPools map[string]*dedicatedPoolWorker
 }
 
@@ -108,6 +113,11 @@ func (d *Driver) Prepare(config []byte) error {
 	}
 	d.quotasMutex.Unlock()
 
+	d.typeCacheMutex.Lock()
+	d.typeCache = make(map[string]int64)
+	d.typeCacheUpdated = make(map[string]time.Time)
+	d.typeCacheMutex.Unlock()
+
 	// Run the background dedicated hosts pool management
 	d.dedicatedPools = make(map[string]*dedicatedPoolWorker)
 	for name, params := range d.cfg.DedicatedPool {
@@ -148,7 +158,9 @@ func (d *Driver) AvailableCapacity(_ /*nodeUsage*/ types.Resources, def types.La
 	if opts.Pool != "" {
 		// The pool is specified - let's check if it has the capacity
 		if p, ok := d.dedicatedPools[opts.Pool]; ok {
-			return p.AvailableCapacity(opts.InstanceType)
+			count := p.AvailableCapacity(opts.InstanceType)
+			log.Debugf("AWS: AvailableCapacity: Pool: %s, Type: %s, Count: %d", opts.Pool, opts.InstanceType, count)
+			return count
 		}
 		log.Warn("AWS: Unable to locate dedicated pool:", opts.Pool)
 		return -1
@@ -175,7 +187,15 @@ func (d *Driver) AvailableCapacity(_ /*nodeUsage*/ types.Resources, def types.La
 				log.Error("AWS: Error during requesting hosts:", err)
 				return -1
 			}
-			instCount += int64(len(resp.Hosts))
+			if len(resp.Hosts) > 0 {
+				for _, host := range resp.Hosts {
+					// Mac capacity is only one per host, so if it already have
+					// an allocated instance - then no slots are here
+					if len(host.Instances) == 0 {
+						instCount += 1
+					}
+				}
+			}
 		}
 
 		log.Debug("AWS: AvailableCapacity for dedicated Mac:", opts.InstanceType, instCount)
@@ -184,6 +204,21 @@ func (d *Driver) AvailableCapacity(_ /*nodeUsage*/ types.Resources, def types.La
 	}
 
 	// On-Demand hosts
+
+	// Checking cached capacity per requested instance type to prevent spam to the AWS API
+	d.typeCacheMutex.Lock()
+	defer d.typeCacheMutex.Unlock()
+	if upd, ok := d.typeCacheUpdated[opts.InstanceType]; ok {
+		if upd.After(time.Now().Add(-30 * time.Second)) {
+			if val, ok := d.typeCache[opts.InstanceType]; ok {
+				log.Debugf("AWS: AvailableCapacity: Type: %s, Cache: %d", opts.InstanceType, val)
+				return val
+			}
+		}
+	}
+
+	// Cache miss, so requesting the actual data from AWS API
+
 	d.updateQuotas(false)
 
 	d.quotasMutex.Lock()
@@ -250,10 +285,16 @@ func (d *Driver) AvailableCapacity(_ /*nodeUsage*/ types.Resources, def types.La
 	log.Debugf("AWS: AvailableCapacity: Type: %s, Quotas: %d, IP's: %d", opts.InstanceType, instCount, ipCount)
 
 	// Return the most limiting value
+	result := instCount
 	if ipCount < instCount {
-		return ipCount
+		result = ipCount
 	}
-	return instCount
+
+	// Updating cache (d.typeCacheMutex is locked earlier)
+	d.typeCacheUpdated[opts.InstanceType] = time.Now()
+	d.typeCache[opts.InstanceType] = result
+
+	return result
 }
 
 // Allocate Instance with provided image

--- a/lib/drivers/aws/driver.go
+++ b/lib/drivers/aws/driver.go
@@ -192,7 +192,7 @@ func (d *Driver) AvailableCapacity(_ /*nodeUsage*/ types.Resources, def types.La
 					// Mac capacity is only one per host, so if it already have
 					// an allocated instance - then no slots are here
 					if len(host.Instances) == 0 {
-						instCount += 1
+						instCount++
 					}
 				}
 			}

--- a/tests/cleanupdb_fish_restart_test.go
+++ b/tests/cleanupdb_fish_restart_test.go
@@ -1,0 +1,195 @@
+/**
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/steinfletcher/apitest"
+
+	"github.com/adobe/aquarium-fish/lib/openapi/types"
+	h "github.com/adobe/aquarium-fish/tests/helper"
+)
+
+// Allocates application, restarts fish and makes sure cleanup will not happen too early and not too late
+func Test_cleanupdb_fish_restart(t *testing.T) {
+	t.Parallel()
+	afi := h.NewAquariumFish(t, "node-1", `---
+node_location: test_loc
+
+api_address: 127.0.0.1:0
+proxy_ssh_address: 127.0.0.1:0
+
+db_cleanup_delay: 10s
+
+drivers:
+  - name: test
+    cfg:
+      cpu_limit: 4
+      ram_limit: 8`)
+
+	t.Cleanup(func() {
+		afi.Cleanup(t)
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cli := &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: tr,
+	}
+
+	var label types.Label
+	t.Run("Create Label", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.APIAddress("api/v1/label/")).
+			JSON(`{"name":"test-label", "version":1, "definitions": [{"driver":"test", "resources":{"cpu":1,"ram":2}}]}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&label)
+
+		if label.UID == uuid.Nil {
+			t.Fatalf("Label UID is incorrect: %v", label.UID)
+		}
+	})
+
+	var app types.Application
+	t.Run("Create Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Post(afi.APIAddress("api/v1/application/")).
+			JSON(`{"label_UID":"`+label.UID.String()+`"}`).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&app)
+
+		if app.UID == uuid.Nil {
+			t.Fatalf("Application UID is incorrect: %v", app.UID)
+		}
+	})
+
+	var appState types.ApplicationState
+	t.Run("Application should get ALLOCATED in 10 sec", func(t *testing.T) {
+		h.Retry(&h.Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *h.R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&appState)
+
+			if appState.Status != types.ApplicationStatusALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", appState.Status)
+			}
+		})
+	})
+
+	var res types.ApplicationResource
+	t.Run("Resource should be created", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/resource")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&res)
+
+		if res.Identifier == "" {
+			t.Fatalf("Resource identifier is incorrect: %v", res.Identifier)
+		}
+	})
+
+	t.Run("Deallocate the Application", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/deallocate")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End()
+	})
+
+	t.Run("Application should get DEALLOCATED in 10 sec", func(t *testing.T) {
+		h.Retry(&h.Timer{Timeout: 10 * time.Second, Wait: 1 * time.Second}, t, func(r *h.R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusOK).
+				End().
+				JSON(&appState)
+
+			if appState.Status != types.ApplicationStatusDEALLOCATED {
+				r.Fatalf("Application Status is incorrect: %v", appState.Status)
+			}
+		})
+	})
+
+	// Restart the fish node with delay
+	afi.Stop(t)
+	// Wait for 10 seconds to test app after-startup delay
+	time.Sleep(10 * time.Second)
+	afi.Start(t)
+
+	// Wait for 8 seconds to check if app will be still available
+	time.Sleep(8 * time.Second)
+
+	t.Run("Application should be available after 8 sec after start", func(t *testing.T) {
+		apitest.New().
+			EnableNetworking(cli).
+			Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/state")).
+			BasicAuth("admin", afi.AdminToken()).
+			Expect(t).
+			Status(http.StatusOK).
+			End().
+			JSON(&appState)
+
+		if appState.Status != types.ApplicationStatusDEALLOCATED {
+			t.Fatalf("Application Status is incorrect: %v", appState.Status)
+		}
+	})
+
+	t.Run("Application should be cleaned in 5 sec", func(t *testing.T) {
+		h.Retry(&h.Timer{Timeout: 5 * time.Second, Wait: 1 * time.Second}, t, func(r *h.R) {
+			apitest.New().
+				EnableNetworking(cli).
+				Get(afi.APIAddress("api/v1/application/"+app.UID.String()+"/state")).
+				BasicAuth("admin", afi.AdminToken()).
+				Expect(r).
+				Status(http.StatusNotFound).
+				End().
+				JSON(&appState)
+		})
+	})
+}

--- a/tests/helper/fish.go
+++ b/tests/helper/fish.go
@@ -328,4 +328,5 @@ func (afi *AFInstance) Start(tb testing.TB, args ...string) {
 	if failed != "" {
 		tb.Fatalf("ERROR: Failed to init node %q: %s", afi.nodeName, failed)
 	}
+	tb.Log("INFO: Fish is ready:", afi.nodeName)
 }

--- a/tests/three_apps_with_limit_fish_restart_test.go
+++ b/tests/three_apps_with_limit_fish_restart_test.go
@@ -147,9 +147,7 @@ drivers:
 	})
 
 	// Restart the fish app node
-	t.Run("Restart the fish node", func(t *testing.T) {
-		afi.Restart(t)
-	})
+	afi.Restart(t)
 
 	t.Run("2 of 3 Applications should be ALLOCATED right after restart", func(t *testing.T) {
 		for i := range appStates {


### PR DESCRIPTION
The issue with long allocating apps could be solved 2 ways: decrease the allocation time or moving towards better handling the apps in-between the election rounds. Need to think more about the latter, but we already can cache the availability for AWS to not spend hundreds of milliseconds to get the same data from AWS.

## Related Issue

#98 

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

