### PR TITLE
AF-94 Workaround for Merge of bitcask & multiple other fixes for processes

### DIFF
--- a/lib/database/application.go
+++ b/lib/database/application.go
@@ -24,6 +24,9 @@ import (
 
 // ApplicationFind lists Applications by filter
 func (d *Database) ApplicationList() (as []types.Application, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application").List(&as)
 	return as, err
 }
@@ -36,6 +39,9 @@ func (d *Database) ApplicationCreate(a *types.Application) error {
 	if a.Metadata == "" {
 		a.Metadata = "{}"
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
 
 	a.UID = d.NewUID()
 	a.CreatedAt = time.Now()
@@ -56,12 +62,18 @@ func (d *Database) ApplicationCreate(a *types.Application) error {
 
 // ApplicationGet returns Application by UID
 func (d *Database) ApplicationGet(uid types.ApplicationUID) (a *types.Application, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application").Get(uid.String(), &a)
 	return a, err
 }
 
 // ApplicationDelete removes the Application
 func (d *Database) ApplicationDelete(uid types.ApplicationUID) (err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("application").Delete(uid.String())
 }
 

--- a/lib/database/application_resource.go
+++ b/lib/database/application_resource.go
@@ -28,6 +28,9 @@ import (
 
 // ApplicationResourceList returns a list of all known ApplicationResource objects
 func (d *Database) ApplicationResourceList() (rs []types.ApplicationResource, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_resource").List(&rs)
 	return rs, err
 }
@@ -64,6 +67,9 @@ func (d *Database) ApplicationResourceCreate(r *types.ApplicationResource) error
 		return fmt.Errorf("Fish: Metadata can't be empty")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	r.UID = d.NewUID()
 	r.CreatedAt = time.Now()
 	r.UpdatedAt = r.CreatedAt
@@ -78,18 +84,28 @@ func (d *Database) ApplicationResourceDelete(uid types.ApplicationResourceUID) e
 		// This issue is not a big deal, because most of the time there is no access to delete
 		log.Debugf("Unable to delete ApplicationResourceAccess associated with ApplicationResourceUID %s: %v", uid, err)
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	// Now purge the resource.
 	return d.be.Collection("application_resource").Delete(uid.String())
 }
 
 // ApplicationResourceSave stores ApplicationResource
 func (d *Database) ApplicationResourceSave(res *types.ApplicationResource) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	res.UpdatedAt = time.Now()
 	return d.be.Collection("application_resource").Add(res.UID.String(), res)
 }
 
 // ApplicationResourceGet returns Resource by it's UID
 func (d *Database) ApplicationResourceGet(uid types.ApplicationResourceUID) (res *types.ApplicationResource, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_resource").Get(uid.String(), &res)
 	return res, err
 }

--- a/lib/database/application_resource_access.go
+++ b/lib/database/application_resource_access.go
@@ -24,6 +24,9 @@ import (
 
 // ApplicationResourceAccessList returns a list of all known ApplicationResourceAccess objects
 func (d *Database) ApplicationResourceAccessList() (ra []types.ApplicationResourceAccess, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_resource_access").List(&ra)
 	return ra, err
 }
@@ -40,6 +43,9 @@ func (d *Database) ApplicationResourceAccessCreate(ra *types.ApplicationResource
 		return fmt.Errorf("Fish: Password can't be empty")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	ra.UID = d.NewUID()
 	ra.CreatedAt = time.Now()
 	return d.be.Collection("application_resource_access").Add(ra.UID.String(), ra)
@@ -47,6 +53,9 @@ func (d *Database) ApplicationResourceAccessCreate(ra *types.ApplicationResource
 
 // ApplicationResourceAccessDelete removes ResourceAccess by UID
 func (d *Database) ApplicationResourceAccessDelete(uid types.ApplicationResourceAccessUID) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("application_resource_access").Delete(uid.String())
 }
 

--- a/lib/database/application_state.go
+++ b/lib/database/application_state.go
@@ -54,7 +54,7 @@ func (d *Database) ApplicationStateCreate(as *types.ApplicationState) error {
 	// Notifying the subscribers on change, doing that in goroutine to not block execution
 	go func(appState *types.ApplicationState) {
 		for _, ch := range d.subsApplicationState {
-			ch <- as
+			ch <- appState
 		}
 	}(as)
 

--- a/lib/database/application_state.go
+++ b/lib/database/application_state.go
@@ -28,6 +28,9 @@ func (d *Database) SubscribeApplicationState(ch chan *types.ApplicationState) {
 
 // ApplicationStateList returns list of ApplicationStates
 func (d *Database) ApplicationStateList() (ass []types.ApplicationState, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_state").List(&ass)
 	return ass, err
 }
@@ -41,31 +44,45 @@ func (d *Database) ApplicationStateCreate(as *types.ApplicationState) error {
 		return fmt.Errorf("Fish: Status can't be empty")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	as.UID = d.NewUID()
 	as.CreatedAt = time.Now()
 	err := d.be.Collection("application_state").Add(as.UID.String(), as)
 
-	// Notifying the subscribers on change
-	for _, ch := range d.subsApplicationState {
-		ch <- as
-	}
+	// Notifying the subscribers on change, doing that in goroutine to not block execution
+	go func(appState *types.ApplicationState) {
+		for _, ch := range d.subsApplicationState {
+			ch <- as
+		}
+	}(as)
 
 	return err
 }
 
 // Intentionally disabled, application state can't be updated
 /*func (d *Database) ApplicationStateSave(as *types.ApplicationState) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Save(as).Error
 }*/
 
 // ApplicationStateGet returns specific ApplicationState
 func (d *Database) ApplicationStateGet(uid types.ApplicationStateUID) (as *types.ApplicationState, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_state").Get(uid.String(), &as)
 	return as, err
 }
 
 // ApplicationStateDelete removes the ApplicationState
 func (d *Database) ApplicationStateDelete(uid types.ApplicationStateUID) (err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("application_state").Delete(uid.String())
 }
 
@@ -147,19 +164,24 @@ func (d *Database) ApplicationStateGetByApplication(appUID types.ApplicationUID)
 	return state, err
 }
 
-// ApplicationStateIsActive returns false if Status in ERROR, DEALLOCATE or DEALLOCATED state
-func (*Database) ApplicationStateIsActive(status types.ApplicationStatus) bool {
-	if status == types.ApplicationStatusERROR {
-		return false
-	}
+// ApplicationStateIsActive returns false if Status in ERROR, RECALLED, DEALLOCATE or DEALLOCATED state
+func (d *Database) ApplicationStateIsActive(status types.ApplicationStatus) bool {
 	if status == types.ApplicationStatusDEALLOCATE {
 		return false
 	}
+	return !d.ApplicationStateIsDead(status)
+}
+
+// ApplicationStateIsDead returns false if Status in ERROR, RECALLED or DEALLOCATED state
+func (*Database) ApplicationStateIsDead(status types.ApplicationStatus) bool {
+	if status == types.ApplicationStatusERROR {
+		return true
+	}
 	if status == types.ApplicationStatusRECALLED {
-		return false
+		return true
 	}
 	if status == types.ApplicationStatusDEALLOCATED {
-		return false
+		return true
 	}
-	return true
+	return false
 }

--- a/lib/database/application_task.go
+++ b/lib/database/application_task.go
@@ -28,6 +28,9 @@ func (d *Database) SubscribeApplicationTask(ch chan *types.ApplicationTask) {
 
 // ApplicationTaskList returns all known ApplicationTasks
 func (d *Database) ApplicationTaskList() (at []types.ApplicationTask, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_task").List(&at)
 	return at, err
 }
@@ -60,16 +63,21 @@ func (d *Database) ApplicationTaskCreate(at *types.ApplicationTask) error {
 		at.Result = util.UnparsedJSON("{}")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	at.UID = d.NewUID()
 	at.CreatedAt = time.Now()
 	at.UpdatedAt = at.CreatedAt
 
 	err := d.be.Collection("application_task").Add(at.UID.String(), at)
 
-	// Notifying the subscribers on change
-	for _, ch := range d.subsApplicationTask {
-		ch <- at
-	}
+	// Notifying the subscribers on change, doing that in goroutine to not block execution
+	go func(appState *types.ApplicationTask) {
+		for _, ch := range d.subsApplicationTask {
+			ch <- at
+		}
+	}(at)
 
 	return err
 }
@@ -79,17 +87,27 @@ func (d *Database) ApplicationTaskSave(at *types.ApplicationTask) error {
 	if at.UID == uuid.Nil {
 		return fmt.Errorf("Fish: UID can't be unset")
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("application_task").Add(at.UID.String(), at)
 }
 
 // ApplicationTaskGet returns the ApplicationTask by ApplicationTaskUID
 func (d *Database) ApplicationTaskGet(uid types.ApplicationTaskUID) (at *types.ApplicationTask, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("application_task").Get(uid.String(), &at)
 	return at, err
 }
 
 // ApplicationTaskDelete removes the ApplicationTask
 func (d *Database) ApplicationTaskDelete(uid types.ApplicationTaskUID) (err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("application_task").Delete(uid.String())
 }
 

--- a/lib/database/application_task.go
+++ b/lib/database/application_task.go
@@ -73,9 +73,9 @@ func (d *Database) ApplicationTaskCreate(at *types.ApplicationTask) error {
 	err := d.be.Collection("application_task").Add(at.UID.String(), at)
 
 	// Notifying the subscribers on change, doing that in goroutine to not block execution
-	go func(appState *types.ApplicationTask) {
+	go func(appTask *types.ApplicationTask) {
 		for _, ch := range d.subsApplicationTask {
-			ch <- at
+			ch <- appTask
 		}
 	}(at)
 

--- a/lib/database/node.go
+++ b/lib/database/node.go
@@ -24,12 +24,18 @@ import (
 
 // NodeFind returns list of Nodes that fits filter
 func (d *Database) NodeList() (ns []types.Node, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("node").List(&ns)
 	return ns, err
 }
 
 // NodeGet returns Node by it's unique name
 func (d *Database) NodeGet(name string) (node *types.Node, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("node").Get(name, &node)
 	return node, err
 }
@@ -59,6 +65,9 @@ func (d *Database) NodeCreate(n *types.Node) error {
 		return fmt.Errorf("Fish: Node should be initialized before create")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	// Create node UUID based on the public key
 	hash := sha256.New()
 	hash.Write(*n.Pubkey)
@@ -70,6 +79,9 @@ func (d *Database) NodeCreate(n *types.Node) error {
 
 // NodeSave stores Node
 func (d *Database) NodeSave(node *types.Node) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	node.UpdatedAt = time.Now()
 	return d.be.Collection("node").Add(node.Name, node)
 }

--- a/lib/database/raw.go
+++ b/lib/database/raw.go
@@ -29,6 +29,10 @@ func (d *Database) Has(prefix, key string) (bool, error) {
 	if strings.Contains(fullkey, "/") {
 		return false, fmt.Errorf("DB: Has can't use '/' in key: %s", fullkey)
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Has(bitcask.Key(fullkey)), nil
 }
 
@@ -38,6 +42,10 @@ func (d *Database) Get(prefix, key string, obj any) error {
 	if strings.Contains(fullkey, "/") {
 		return fmt.Errorf("DB: Get can't use '/' in key: %s", fullkey)
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	data, err := d.be.Get(bitcask.Key(fullkey))
 	if err != nil {
 		if err == bitcask.ErrKeyNotFound {
@@ -59,6 +67,10 @@ func (d *Database) Set(prefix, key string, obj any) error {
 	if err != nil {
 		return fmt.Errorf("DB: Set can't serialize value to json: %v", err)
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Put(bitcask.Key(fullkey), v)
 }
 
@@ -68,6 +80,10 @@ func (d *Database) Del(prefix, key string) error {
 	if strings.Contains(fullkey, "/") {
 		return fmt.Errorf("DB: Del can't use '/' in key: %s", fullkey)
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Delete(bitcask.Key(fullkey))
 }
 
@@ -76,6 +92,10 @@ func (d *Database) Scan(prefix string, f func(string) error) error {
 	if strings.Contains(prefix, "/") {
 		return fmt.Errorf("DB: Scan can't use '/' in prefix: %s", prefix)
 	}
+
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Scan(bitcask.Key(prefix+":"), func(bkey bitcask.Key) error {
 		key := strings.SplitN(string(bkey), ":", 2)[1]
 		// Skipping keys with "/"

--- a/lib/database/servicemapping.go
+++ b/lib/database/servicemapping.go
@@ -21,6 +21,9 @@ import (
 
 // ServiceMappingFind returns list of ServiceMappings that fits the filter
 func (d *Database) ServiceMappingList() (sms []types.ServiceMapping, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("service_mapping").List(&sms)
 	return sms, err
 }
@@ -34,6 +37,9 @@ func (d *Database) ServiceMappingCreate(sm *types.ServiceMapping) error {
 		return fmt.Errorf("Fish: Redirect can't be empty")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	sm.UID = d.NewUID()
 	sm.CreatedAt = time.Now()
 	return d.be.Collection("service_mapping").Add(sm.UID.String(), sm)
@@ -41,17 +47,26 @@ func (d *Database) ServiceMappingCreate(sm *types.ServiceMapping) error {
 
 // ServiceMappingSave stores ServiceMapping
 func (d *Database) ServiceMappingSave(sm *types.ServiceMapping) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("service_mapping").Add(sm.UID.String(), sm)
 }
 
 // ServiceMappingGet returns ServiceMapping by UID
 func (d *Database) ServiceMappingGet(uid types.ServiceMappingUID) (sm *types.ServiceMapping, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("service_mapping").Get(uid.String(), &sm)
 	return sm, err
 }
 
 // ServiceMappingDelete removes ServiceMapping
 func (d *Database) ServiceMappingDelete(uid types.ServiceMappingUID) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("service_mapping").Delete(uid.String())
 }
 

--- a/lib/database/user.go
+++ b/lib/database/user.go
@@ -23,6 +23,9 @@ import (
 
 // UserList returns list of users
 func (d *Database) UserList() (us []types.User, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("user").List(&us)
 	return us, err
 }
@@ -36,6 +39,9 @@ func (d *Database) UserCreate(u *types.User) error {
 		return fmt.Errorf("Fish: Hash can't be empty")
 	}
 
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	u.CreatedAt = time.Now()
 	u.UpdatedAt = u.CreatedAt
 	return d.be.Collection("user").Add(u.Name, u)
@@ -43,18 +49,27 @@ func (d *Database) UserCreate(u *types.User) error {
 
 // UserSave stores User
 func (d *Database) UserSave(u *types.User) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	u.UpdatedAt = time.Now()
 	return d.be.Collection("user").Add(u.Name, &u)
 }
 
 // UserGet returns User by unique name
 func (d *Database) UserGet(name string) (u *types.User, err error) {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	err = d.be.Collection("user").Get(name, &u)
 	return u, err
 }
 
 // UserDelete removes User
 func (d *Database) UserDelete(name string) error {
+	d.beMu.RLock()
+	defer d.beMu.RUnlock()
+
 	return d.be.Collection("user").Delete(name)
 }
 

--- a/lib/drivers/drivers.go
+++ b/lib/drivers/drivers.go
@@ -46,6 +46,9 @@ var providerDrivers map[string]provider.Driver
 
 // Init loads and prepares all kind of available drivers
 func Init(db *database.Database, wd string, configs ConfigDrivers) error {
+	log.Debug("Drivers: Running init...")
+	defer log.Debug("Drivers: Init completed")
+
 	if err := load(db, configs); err != nil {
 		return log.Error("Drivers: Unable to load drivers:", err)
 	}
@@ -61,6 +64,9 @@ func Init(db *database.Database, wd string, configs ConfigDrivers) error {
 
 // load making the drivers instances map with specified names
 func load(db *database.Database, configs ConfigDrivers) error {
+	log.Debug("Drivers: Running load...")
+	defer log.Debug("Drivers: Load completed")
+
 	// Loading providers
 	providerInstances := make(map[string]provider.Driver)
 
@@ -122,6 +128,8 @@ func load(db *database.Database, configs ConfigDrivers) error {
 
 // prepare initializes the drivers with provided configs
 func prepare(wd string, configs ConfigDrivers) (ok bool, errs []error) {
+	log.Debug("Drivers: Running prepare...")
+	defer log.Debug("Drivers: Prepare completed")
 	mandatoryDriversLoaded := true
 
 	// Activating providers

--- a/lib/fish/config.go
+++ b/lib/fish/config.go
@@ -23,6 +23,7 @@ import (
 )
 
 const DefaultDBCleanupInterval = 10 * time.Minute
+const DefaultDBCompactInterval = time.Hour
 
 // Config defines Fish node configuration
 type Config struct {
@@ -49,6 +50,7 @@ type Config struct {
 	ElectedRoundsToWait uint8 `json:"elected_rounds_to_wait"` // Preventive measure for Node failure on ELECTED state, recovers election after this amount of rounds, default: 10
 
 	DBCleanupInterval util.Duration `json:"db_cleanup_interval"` // Defines the database item cleanup interval when Application reached the end of life (by error or deallocated)
+	DBCompactInterval util.Duration `json:"db_compact_interval"` // Defines the database compaction interval to get rid of old data on disk periodically
 
 	DisableAuth bool `json:"disable_auth"` // WARNING! For performance testing only
 
@@ -95,4 +97,5 @@ func (c *Config) initDefaults() {
 	c.AllocationRetry = 3
 	c.ElectedRoundsToWait = 10
 	c.DBCleanupInterval = util.Duration(DefaultDBCleanupInterval)
+	c.DBCompactInterval = util.Duration(DefaultDBCompactInterval)
 }

--- a/lib/fish/election.go
+++ b/lib/fish/election.go
@@ -118,7 +118,7 @@ func (f *Fish) electionProcess(appUID types.ApplicationUID) error {
 			// for the new executor now to run the Application. We can't change the state,
 			// of the Application (since no primary executor is here), so just continue to
 			// use ELECTED state.
-			log.Warnf("Fish: Election %s: Elected node did not allocated the Applciation, reruning election on round %d", appUID, myvote.Round)
+			log.Warnf("Fish: Election %s: Elected node did not allocated the Application, reruning election on round %d", appUID, myvote.Round)
 			electedRoundsToWait = -1
 		} else if appState.Status != types.ApplicationStatusNEW {
 			log.Debugf("Fish: Election %s: Completed with status: %s", appUID, appState.Status)
@@ -151,6 +151,20 @@ func (f *Fish) electionProcess(appUID types.ApplicationUID) error {
 			}
 			if len(votes) < len(nodes) {
 				log.Debugf("Fish: Election %s: Some nodes didn't vote in round %d (%d < %d), waiting till %v...", appUID, myvote.Round, len(votes), len(nodes), roundEndsAt)
+				if len(votes) == 0 {
+					log.Warnf("Fish: Election %q: Something weird happened (votes len can't be 0), here is additional info:", appUID)
+					log.Warnf("Fish: Election %q:   Vote UID:", appUID, myvote.UID)
+					f.activeVotesMutex.Lock()
+					log.Warnf("Fish: Election %q:   List of active votes: %+v", appUID, f.activeVotes)
+					f.activeVotesMutex.Unlock()
+					f.storageVotesMutex.Lock()
+					log.Warnf("Fish: Election %q:   List of storage votes: %+v", appUID, f.storageVotes)
+					f.storageVotesMutex.Unlock()
+
+					// Recovering
+					myvote.UID = uuid.Nil
+					break
+				}
 
 				// Wait 5 sec and repeat
 				time.Sleep(5 * time.Second)

--- a/lib/fish/election.go
+++ b/lib/fish/election.go
@@ -84,8 +84,10 @@ func (f *Fish) electionProcess(appUID types.ApplicationUID) error {
 
 		// Check if the Application is good to go or maybe we need to wait until the change
 		if appState, err := f.db.ApplicationStateGetByApplication(appUID); err != nil {
-			log.Errorf("Fish: Election %s: Unable to get the Application state: %v", appUID, err)
-			// The Application state is not found, so we can drop the election process
+			// If the cleanup is set to very tight limit (< ElectionRoundTime) - the Application
+			// can actually complete it's journey before election process confirms it's state, so
+			// not existing Application can't be elected anymore and we can safely drop here
+			log.Infof("Fish: Election %s: Application state is missing, dropping the election: %v", appUID, err)
 			f.activeVotesRemove(myvote.UID)
 			f.storageVotesCleanup()
 			return nil

--- a/lib/fish/execute.go
+++ b/lib/fish/execute.go
@@ -420,7 +420,7 @@ func (f *Fish) executeApplicationStop(appUID types.ApplicationUID) error {
 		// deallocation by DEALLOCATE & RECALLED which is useful for `snapshot` and `image` tasks.
 		f.executeApplicationTasks(driver, &labelDef, res, appState.Status)
 
-		log.Infof("Fish: Application %s: Stop: Running Deallocate of the ApplicationResource:", appUID, res.Identifier)
+		log.Infof("Fish: Application %s: Stop: Running Deallocate of the ApplicationResource: %s", appUID, res.Identifier)
 
 		// Deallocating and destroy the resource
 		for retry := range 20 {

--- a/lib/fish/fish.go
+++ b/lib/fish/fish.go
@@ -194,12 +194,16 @@ func (f *Fish) Init() error {
 		return log.Error("Fish: Unable to init drivers:", err)
 	}
 
-	// Resume to execute the assigned Applications
+	// Run application state processing before resuming the assigned Applications
+	go f.applicationProcess()
+
+	log.Debug("Fish: Resuming to execute the assigned Applications...")
 	resources, err := f.db.ApplicationResourceListNode(f.db.GetNodeUID())
 	if err != nil {
 		return log.Error("Fish: Unable to get the node resources:", err)
 	}
 	for _, res := range resources {
+		log.Debugf("Fish: Resuming Resource execution for Application: %q", res.ApplicationUID)
 		if f.db.ApplicationIsAllocated(res.ApplicationUID) == nil {
 			log.Info("Fish: Found allocated resource to serve:", res.UID)
 			// We will not retry here, because the mentioned Applications should be already running
@@ -214,14 +218,15 @@ func (f *Fish) Init() error {
 			if err := f.db.ApplicationResourceDelete(res.UID); err != nil {
 				log.Error("Fish: Unable to delete Resource of Application:", res.ApplicationUID, err)
 			}
-			appState := &types.ApplicationState{ApplicationUID: res.ApplicationUID, Status: types.ApplicationStatusERROR,
+			appState := types.ApplicationState{
+				ApplicationUID: res.ApplicationUID, Status: types.ApplicationStatusERROR,
 				Description: "Found not cleaned up resource",
 			}
-			f.db.ApplicationStateCreate(appState)
+			f.db.ApplicationStateCreate(&appState)
 		}
 	}
 
-	// Resume electionProcess for the NEW and ELECTED Applications
+	log.Debug("Fish: Resuming electionProcess for the NEW and ELECTED Applications...")
 	electionAppStates, err := f.db.ApplicationStateListNewElected()
 	if err != nil {
 		return log.Error("Fish: Unable to get NEW and ELECTED ApplicationState list:", err)
@@ -231,11 +236,10 @@ func (f *Fish) Init() error {
 		f.maybeRunElectionProcess(&appState)
 	}
 
+	log.Debug("Fish: Running background processes...")
+
 	// Run node ping timer
 	go f.pingProcess()
-
-	// Run application vote process
-	go f.applicationProcess()
 
 	// Run ARP autoupdate process to ensure the addresses will be ok
 	arp.AutoRefresh(30 * time.Second)
@@ -384,7 +388,7 @@ func (f *Fish) CleanupDB() {
 		return
 	}
 	for _, state := range states {
-		if state.Status != types.ApplicationStatusERROR && state.Status != types.ApplicationStatusDEALLOCATED {
+		if !f.db.ApplicationStateIsDead(state.Status) {
 			continue
 		}
 		log.Debugf("Fish: CleanupDB: Checking Application %s (%s): %v", state.ApplicationUID, state.Status, state.CreatedAt)

--- a/lib/fish/fish.go
+++ b/lib/fish/fish.go
@@ -331,7 +331,9 @@ func (f *Fish) applicationProcess() {
 				f.maybeRunExecuteApplicationStop(appState)
 			case types.ApplicationStatusDEALLOCATED, types.ApplicationStatusERROR:
 				// Not much to do here, but maybe later in the future?
-				f.maybeRunApplicationTask(appState.ApplicationUID, nil)
+				// In this state the Application has no Resource to deal with, so no luck for now
+				//f.maybeRunApplicationTask(appState.ApplicationUID, nil)
+				log.Debugf("Fish: Application %s reached end state %s", appState.ApplicationUID, appState.Status)
 			}
 		case appTask := <-f.applicationTaskChannel:
 			// Runs check for Application state and decides if need to execute or drop
@@ -356,8 +358,9 @@ func (f *Fish) dbCleanupCompactProcess() {
 	defer cleanupTicker.Stop()
 	log.Infof("Fish: dbCleanupCompactProcess: Triggering CleanupDB once per %s", dbCleanupDelay/2)
 
-	compactionTicker := time.NewTicker(time.Hour)
-	log.Infof("Fish: dbCleanupCompactProcess: Triggering CompactDB once per %s", time.Hour)
+	dbCompactDelay := time.Duration(f.cfg.DBCompactInterval)
+	compactionTicker := time.NewTicker(dbCompactDelay)
+	log.Infof("Fish: dbCleanupCompactProcess: Triggering CompactDB once per %s", dbCompactDelay)
 	defer compactionTicker.Stop()
 
 	for {


### PR DESCRIPTION
Change was made based on extensive / stress testing of the fish node, which helped to identify:

* Issue with bitcask on executing Merge operation - it was not designed to be executed in parallel with the regular DB operations and leaded to issues with requests as well as corruption of the database on disk and in memory: https://git.mills.io/prologic/bitcask/issues/276 - when it will be solved we can remove the mutex. Workaround implements simple RW mutex to separate CompactDB operation with regular DB utilization tasks. Special test was added to ensure it's working correctly.
* Channels send operations was moved to goroutines to not block the application background process and init phase.
* Previously was missed RECALLED status now also a part of cleanup procedures, so recalled apps now will be cleaned up as well.
* Other small fixes here as well

## Related Issue

#94

## Motivation and Context

Keeping the things stable and nice before release

## How Has This Been Tested?

Stress tests & automatic tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

