### PR TITLE
AF-94 Fixed issue with leftover app timeouts and btw added VMX raw disk

### DIFF
--- a/lib/fish/execute.go
+++ b/lib/fish/execute.go
@@ -433,7 +433,7 @@ func (f *Fish) executeApplicationStop(appUID types.ApplicationUID) error {
 				continue
 			}
 
-			log.Infof("Fish: Application %s: Stop: Successful deallocation of the Application:", appUID)
+			log.Infof("Fish: Application %s: Stop: Application deallocated successfully", appUID)
 			appState = &types.ApplicationState{ApplicationUID: appUID, Status: types.ApplicationStatusDEALLOCATED,
 				Description: "Driver deallocated the resource",
 			}
@@ -537,8 +537,10 @@ func (f *Fish) applicationTimeoutSet(uid types.ApplicationUID, to time.Time) {
 	f.applicationsTimeouts[uid] = to
 
 	if needUpdate {
-		// Notifying the process on updated
-		f.applicationsTimeoutsUpdated <- struct{}{}
+		// Notifying the process on updated in background to not block the process execution
+		go func() {
+			f.applicationsTimeoutsUpdated <- struct{}{}
+		}()
 	}
 }
 
@@ -566,8 +568,10 @@ func (f *Fish) applicationTimeoutRemove(uid types.ApplicationUID) {
 	}
 
 	if needUpdate {
-		// Notifying the process on updated
-		f.applicationsTimeoutsUpdated <- struct{}{}
+		// Notifying the process on updated in background to not block the process execution
+		go func() {
+			f.applicationsTimeoutsUpdated <- struct{}{}
+		}()
 	}
 }
 

--- a/tests/compactdb_check_test.go
+++ b/tests/compactdb_check_test.go
@@ -33,6 +33,7 @@ func Test_compactdb_check(t *testing.T) {
 	t.Parallel()
 	afi := h.NewAquariumFish(t, "node-1", `---
 node_location: test_loc
+default_resource_lifetime: 20s
 
 api_address: 127.0.0.1:0
 

--- a/tests/helper/fish.go
+++ b/tests/helper/fish.go
@@ -65,7 +65,12 @@ func NewAfInstance(tb testing.TB, name, cfg string) *AFInstance {
 		waitForLog: make(map[string]func(string, string) bool),
 	}
 
-	afi.workspace = tb.TempDir()
+	// Not using here tb.TempDir to have an ability to save on cleanup for investigation
+	var err error
+	if afi.workspace, err = os.MkdirTemp("", "fish"); err != nil {
+		tb.Fatal("INFO: Unable to create workspace:", afi.nodeName, err)
+		return nil
+	}
 	tb.Log("INFO: Created workspace:", afi.nodeName, afi.workspace)
 
 	cfg += fmt.Sprintf("\nnode_name: %q", afi.nodeName)
@@ -146,6 +151,11 @@ func (afi *AFInstance) Cleanup(tb testing.TB) {
 	tb.Helper()
 	tb.Log("INFO: Cleaning up:", afi.nodeName, afi.workspace)
 	afi.Stop(tb)
+
+	if tb.Failed() {
+		tb.Log("INFO: Keeping workspace for checking:", afi.workspace)
+		return
+	}
 	os.RemoveAll(afi.workspace)
 }
 


### PR DESCRIPTION
Two changes here:
* After a night of testing I found the app timeout is not working correctly - it's just creating the state not checking if the app exists, so bloating the database. Added a quick fix for that and now removing app timeout on deallocation. Updated compactdb test to check this behavior as well. Also found deadlock with channels there - oh those channels...
* Also today we found that git >=2.35 don't really like to be running on windows with wrong owner for the workspace, so I've added VMX driver ability to create raw disks instead of formatting them on the host system to the limited amount of filesystems. That was a relatively legacy feature, so with modern bait images containing diskmount role (which is formatting the attached raw disks) we don't need to strictly rely on host OS for that and can easily format the disk during the VM init procedures.

**WARNING:** VMX driver disks default was changed - before type of disk by default was "extfs", now it's "raw" and you need to change your labels to use `type: "extfs"` if you did not defined that or defined as empty string value.

## Related Issue

#94 

## Motivation and Context

BSF!

## How Has This Been Tested?

Manually & automatically

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

