### PR TITLE
AF-61 Connected AWS to ProxySSH

### DIFF
--- a/lib/drivers/gate/proxyssh/config.go
+++ b/lib/drivers/gate/proxyssh/config.go
@@ -37,7 +37,7 @@ func (c *Config) Apply(config []byte, db *database.Database) error {
 	}
 
 	if c.BindAddress == "" {
-		c.BindAddress = "0.0.0.0:1022"
+		c.BindAddress = "0.0.0.0:1222"
 	}
 
 	if c.SSHKey == "" {

--- a/lib/drivers/provider/aws/config.go
+++ b/lib/drivers/provider/aws/config.go
@@ -33,9 +33,10 @@ type Config struct {
 	SecretKey string `json:"secret_key"` // AWS AMI Secret Key
 
 	// Optional
-	AccountIDs   []string          `json:"account_ids"`   // AWS Trusted account IDs to filter vpc, subnet, sg, images, snapshots...
-	InstanceTags map[string]string `json:"instance_tags"` // AWS Instance tags to use when this node provision them
-	InstanceKey  string            `json:"instance_key"`  // AWS Instance Key Pair name to use while creating of the instance
+	AccountIDs        []string          `json:"account_ids"`         // AWS Trusted account IDs to filter vpc, subnet, sg, images, snapshots...
+	InstanceTags      map[string]string `json:"instance_tags"`       // AWS Instance tags to use when this node provision them
+	InstanceKey       string            `json:"instance_key"`        // AWS Instance Key Pair name to use while creating of the instance
+	InstanceKeyPrefix string            `json:"instance_key_prefix"` // AWS prefix for auto-generated Instance Key
 
 	// Manage the AWS dedicated hosts to keep them busy and deallocate when not needed
 	// Key of the map is name of the pool - will be used for identification of the pool
@@ -173,6 +174,9 @@ func (c *Config) Validate() (err error) {
 	// Init empty instance tags in case its not set
 	if c.InstanceTags == nil {
 		c.InstanceTags = make(map[string]string)
+	}
+	if c.InstanceKeyPrefix == "" {
+		c.InstanceKeyPrefix = "fish_ssh_instance_key_"
 	}
 	// Init empty dedicated pool in case its not set
 	if c.DedicatedPool == nil {

--- a/lib/drivers/provider/aws/driver.go
+++ b/lib/drivers/provider/aws/driver.go
@@ -401,6 +401,7 @@ func (d *Driver) Allocate(def types.LabelDefinition, metadata map[string]any) (*
 
 			input.KeyName = aws.String(keyName)
 			keyPem = aws.ToString(result.KeyMaterial)
+			log.Debugf("AWS: %s: Generated keypair: %q", iName, keyName)
 		} else {
 			log.Debugf("AWS: %s: Skipping key generation since no Authentication provided", iName)
 		}
@@ -697,6 +698,8 @@ func (d *Driver) Deallocate(res *types.ApplicationResource) error {
 		if err != nil || result == nil || !aws.ToBool(result.Return) {
 			// It's not critical, but could leave some additional work for cleanup
 			log.Errorf("AWS: %s: Unable to delete keypair %q: %v", res.Identifier, keyName, err)
+		} else {
+			log.Debugf("AWS: %s: Removed generated keypair: %q", iName, keyName)
 		}
 	}
 

--- a/lib/drivers/provider/aws/driver.go
+++ b/lib/drivers/provider/aws/driver.go
@@ -699,7 +699,7 @@ func (d *Driver) Deallocate(res *types.ApplicationResource) error {
 			// It's not critical, but could leave some additional work for cleanup
 			log.Errorf("AWS: %s: Unable to delete keypair %q: %v", res.Identifier, keyName, err)
 		} else {
-			log.Debugf("AWS: %s: Removed generated keypair: %q", iName, keyName)
+			log.Debugf("AWS: %s: Removed generated keypair: %q", res.Identifier, keyName)
 		}
 	}
 

--- a/lib/drivers/provider/aws/options.go
+++ b/lib/drivers/provider/aws/options.go
@@ -30,12 +30,13 @@ import (
 //	tags:
 //	  somekey: somevalue
 type Options struct {
-	Image         string            `json:"image"`          // ID/Name of the image you want to use (name that contains * is usually a bad idea for reproducibility)
-	InstanceType  string            `json:"instance_type"`  // Type of the instance from aws available list
-	SecurityGroup string            `json:"security_group"` // ID/Name of the security group to use for the instance
-	Tags          map[string]string `json:"tags"`           // Tags to add during instance creation
-	EncryptKey    string            `json:"encrypt_key"`    // Use specific encryption key for the new disks
-	Pool          string            `json:"pool"`           // Use machine from dedicated pool, otherwise will try to use one with auto-placement
+	Image          string            `json:"image"`           // ID/Name of the image you want to use (name that contains * is usually a bad idea for reproducibility)
+	InstanceType   string            `json:"instance_type"`   // Type of the instance from aws available list
+	SecurityGroups []string          `json:"security_groups"` // IDs/Names of the security groups to use for the instance
+	SecurityGroup  string            `json:"security_group"`  // ID/Name of the security group to use for the instance (DEPRECATED)
+	Tags           map[string]string `json:"tags"`            // Tags to add during instance creation
+	EncryptKey     string            `json:"encrypt_key"`     // Use specific encryption key for the new disks
+	Pool           string            `json:"pool"`            // Use machine from dedicated pool, otherwise will try to use one with auto-placement
 
 	UserDataFormat string `json:"userdata_format"` // If not empty - will store the resource metadata to userdata in defined format
 	UserDataPrefix string `json:"userdata_prefix"` // Optional if need to add custom prefix to the metadata key during formatting

--- a/lib/openapi/api/api_v1.go
+++ b/lib/openapi/api/api_v1.go
@@ -365,6 +365,8 @@ func (e *Processor) ApplicationResourceGet(c echo.Context, uid types.Application
 
 	// TODO: Implement better way to ignore new fields in java jenkins side of things
 	out.Timeout = nil
+	// It's not a good idea to show the resource authentication params, internal use only
+	out.Authentication = nil
 
 	return c.JSON(http.StatusOK, out)
 }


### PR DESCRIPTION
Change allows to use ProxySSH gate with AWS provider driver.

* Changed default port 1222 for the ProxySSH - old one was 1022, which is in restricted system ports.
* Added ability to generate keypairs if instance_key is set to "generate" Authentication is set for the label - otherwise not spending time on that.
* Added security_groups to be able to specify multiple groups when needed - that makes management of similar firewalls easier.
* Passing Authentication to the Resource
* Modified tags logic to have it common between keys & instances.

## Related Issue

#61 

## Motivation and Context

Need to be done

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

