### PR TITLE
AF-113 Increased AWS stop timeout to 30 mins and made snapshot fail if instance is not stopped

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ version_flags="-X '$mod_name/lib/build.Version=${git_version}' -X '$mod_name/lib
 BINARY_NAME="aquarium-fish-$git_version"
 
 # Doing check after generation because generated sources requires additional modules
-./check.sh
+[ "$SKIPCHECK" ] || ./check.sh
 
 echo
 echo "--- RUN UNIT TESTS ---"

--- a/lib/drivers/gate/proxyssh/proxy.go
+++ b/lib/drivers/gate/proxyssh/proxy.go
@@ -175,14 +175,14 @@ func (s *session) handleChannel(ch ssh.NewChannel, dstConn ssh.Conn) {
 	// Need this local channel work group to wait until all the channel routines completed
 	var chWg sync.WaitGroup
 
+	// Use channels to coordinate copy completion
+	dstToSrcDone := make(chan bool)
+	srcToDstDone := make(chan bool)
+
 	// Proxying the requests
 	chWg.Add(1)
 	go func() {
 		defer chWg.Done()
-
-		// End the communication between the source and destination when this function is complete.
-		defer srcChn.Close()
-		defer dstChn.Close()
 
 		log.Debugf("PROXYSSH: %s: %s: Starting to listen for channel requests", s.drv.name, s.SrcAddr)
 		for {
@@ -191,15 +191,11 @@ func (s *session) handleChannel(ch ssh.NewChannel, dstConn ssh.Conn) {
 
 			select {
 			case request = <-srcChnRequests:
-				//log.Debugf("PROXYSSH: %s: %s: Received src channel request: %v", s.drv.name, s.SrcAddr, request)
 				targetChannel = dstChn
 			case request = <-dstChnRequests:
-				//log.Debugf("PROXYSSH: %s: %s: Received dst channel request: %v", s.drv.name, s.SrcAddr, request)
 				targetChannel = srcChn
 			}
 
-			// In the event that an SSH request gets killed (not exited),
-			// the request will be nil. Do not continue, exit the loop.
 			if request == nil {
 				log.Warnf("PROXYSSH: %s: %s: SSH connection terminated ungracefully...", s.drv.name, s.SrcAddr)
 				break
@@ -220,7 +216,6 @@ func (s *session) handleChannel(ch ssh.NewChannel, dstConn ssh.Conn) {
 
 			log.Debugf("PROXYSSH: %s: %s: Request: Type=%q, WantReply='%t'.", s.drv.name, s.SrcAddr, request.Type, request.WantReply)
 			if request.Type == "exit-status" {
-				// Ending the channel requests processing
 				break
 			}
 		}
@@ -239,13 +234,7 @@ func (s *session) handleChannel(ch ssh.NewChannel, dstConn ssh.Conn) {
 		} else {
 			log.Debugf("PROXYSSH: %s: %s: The dst->src channel was closed: %v", s.drv.name, s.SrcAddr, err)
 		}
-		// Properly closing the channel
-		if err := dstChn.CloseWrite(); err != nil {
-			log.Warnf("PROXYSSH: %s: %s: The dst->src closing write for dst channel did not go well: %v", s.drv.name, s.SrcAddr, err)
-		}
-		if err := srcChn.CloseWrite(); err != nil {
-			log.Warnf("PROXYSSH: %s: %s: The dst->src closing write for src channel did not go well: %v", s.drv.name, s.SrcAddr, err)
-		}
+		close(dstToSrcDone)
 	}()
 
 	if _, err := io.Copy(dstChn, srcChn); err != nil && err != io.EOF {
@@ -253,13 +242,23 @@ func (s *session) handleChannel(ch ssh.NewChannel, dstConn ssh.Conn) {
 	} else {
 		log.Debugf("PROXYSSH: %s: %s: The src->dst channel was closed", s.drv.name, s.SrcAddr)
 	}
-	// Properly closing the channel
-	if err := dstChn.CloseWrite(); err != nil {
-		log.Warnf("PROXYSSH: %s: %s: The src->dst closing write for dst channel did not go well: %v", s.drv.name, s.SrcAddr, err)
+	close(srcToDstDone)
+
+	// Wait for both copies to complete before closing writes
+	<-dstToSrcDone
+	<-srcToDstDone
+
+	// Now safe to close both channels
+	if err := dstChn.CloseWrite(); err != nil && err != io.EOF {
+		log.Warnf("PROXYSSH: %s: %s: Error closing dst channel write: %v", s.drv.name, s.SrcAddr, err)
 	}
-	if err := srcChn.CloseWrite(); err != nil {
-		log.Warnf("PROXYSSH: %s: %s: The src->dst closing write for src channel did not go well: %v", s.drv.name, s.SrcAddr, err)
+	if err := srcChn.CloseWrite(); err != nil && err != io.EOF {
+		log.Warnf("PROXYSSH: %s: %s: Error closing src channel write: %v", s.drv.name, s.SrcAddr, err)
 	}
+
+	// Finally close the channels completely
+	dstChn.Close()
+	srcChn.Close()
 
 	chWg.Wait()
 	log.Debugf("PROXYSSH: %s: %s: Completed processing channel: %s", s.drv.name, s.SrcAddr, ch.ChannelType())

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,0 +1,41 @@
+#!/bin/sh -e
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+# Please set NOBUILD=1 if want to skip build of binary for linux
+# Use first argument to specify the test or skip that and it will run all the tests
+
+TEST="$1"
+
+if [ "x$TEST" != 'x' ]; then
+    test_cmd="-run '^$TEST\$'"
+else
+    test_cmd="-skip '_stress\$'"
+fi
+
+docker run -v $PWD:/ws -w /ws --rm -it golang:1.23.1 sh -exc "
+[ 'x$NOBUILD' != 'x' ] || SKIPCHECK=1 ./build.sh
+
+counter=0
+fish_bin=\$(ls -t aquarium-fish-*.linux_amd64 | head -1)
+
+while true
+do
+    FISH_PATH=\$PWD/\$fish_bin go test -v -failfast -parallel 1 -count=1 $test_cmd ./tests
+
+    counter=\$((\$counter+1))
+    if [ \$counter -ge 50 ]; then
+        break
+    fi
+    sleep 1
+done
+
+echo \$counter
+"

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -12,9 +12,11 @@
 # Please set NOBUILD=1 if want to skip build of binary for linux
 # Use first argument to specify the test or skip that and it will run all the tests
 
-TEST="$1"
+TEST="$@"
 
-if [ "x$TEST" != 'x' ]; then
+if [ "$(echo "x$TEST" | cut -c-2)" = 'x-' ]; then
+    test_cmd="$TEST"
+elif [ "x$TEST" != 'x' ]; then
     test_cmd="-run '^$TEST\$'"
 else
     test_cmd="-skip '_stress\$'"


### PR DESCRIPTION
Fixes the issue with broken snapshot as a result of the task. The consistence is more important then no matter what prepare a snapshot, especially if it's a broken one.

Also partially fixed issue with openssh - now test tty client waits a second for shell response before beginning input - that solves some issues with too early input, but not all of them - for example it seems proxy closes the channel too soon and don't receive "exit", but that's an issue for future me.

## Related Issue

Fixes: #113 

## Motivation and Context

Bug must be exterminated

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

