### PR TITLE
AF-61 Fixed issues with reverse proxy handling and AWS generated keys cleanup

### DIFF
--- a/tests/proxyssh_key_test.go
+++ b/tests/proxyssh_key_test.go
@@ -1030,9 +1030,7 @@ drivers:
 		}
 	})
 
-	// TODO: For some reason mock server does not accept reverse port forwarding, but
-	// I spent too much time on that already, so the direct forwarding enough for testing now
-	/*t.Run("Executing SSH port reverse pass through PROXYSSH", func(t *testing.T) {
+	t.Run("Executing SSH port reverse pass through PROXYSSH", func(t *testing.T) {
 		// Writing ssh private key to temp file
 		proxyKeyFile, err := os.CreateTemp("", "proxykey")
 		if err != nil {
@@ -1076,7 +1074,7 @@ drivers:
 		cmd.Start()
 
 		// Wait for ssh port passthrough startup
-		time.Sleep(2*time.Second)
+		time.Sleep(2 * time.Second)
 
 		// Requesting Fish API through proxied port
 		apitest.New().
@@ -1087,7 +1085,7 @@ drivers:
 			Status(http.StatusOK).
 			End().
 			JSON(&res)
-	})*/
+	})
 
 	t.Run("Deallocate the Application", func(t *testing.T) {
 		apitest.New().


### PR DESCRIPTION
Fixed 2 bugs:

* AWS: Proper cleanup of the instance generated keys - previously used instance id instead of name.
* Fixed issue with ProxySSH reverse port forwarding - now it works just fine.

## Related Issue

#61 

## Motivation and Context

Debugging is closer and closer!

## How Has This Been Tested?

Manually & Automatically

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

