### PR TITLE
AF-137 ApplicationState Remove operations does not trigger subscriptions

### DIFF
--- a/lib/database/application_state.go
+++ b/lib/database/application_state.go
@@ -83,21 +83,12 @@ func (d *Database) applicationStateGetImpl(_ context.Context, uid typesv2.Applic
 }
 
 // applicationStateDeleteImpl removes the ApplicationState
-func (d *Database) applicationStateDeleteImpl(ctx context.Context, uid typesv2.ApplicationStateUID) (err error) {
-	// Get the object before deleting it for notification
-	as, getErr := d.ApplicationStateGet(ctx, uid)
-	if getErr != nil {
-		return getErr
-	}
-
+func (d *Database) applicationStateDeleteImpl(_ context.Context, uid typesv2.ApplicationStateUID) (err error) {
 	d.beMu.RLock()
 	err = d.be.Collection(ObjectApplicationState).Delete(uid.String())
 	d.beMu.RUnlock()
 
-	if err == nil && as != nil {
-		// Notify subscribers about the removed ApplicationState
-		notifySubscribersHelper(d, &d.subsApplicationState, NewRemoveEvent(as), ObjectApplicationState)
-	}
+	// NOTE: ApplicationState matters only on creation, remove happens on CleanupDB, so skipping notification
 
 	return err
 }

--- a/lib/log/console.go
+++ b/lib/log/console.go
@@ -251,6 +251,8 @@ func (h *ConsoleHandler) appendAttr(buf *strings.Builder, attr slog.Attr) {
 			switch v := attr.Value.Any().(type) {
 			case fmt.Stringer:
 				buf.WriteString(v.String())
+			case error:
+				buf.WriteString(v.Error())
 			default:
 				buf.WriteString(fmt.Sprintf("%#v", v))
 			}

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -137,7 +137,7 @@ func Initialize(config *Config) error {
 	if config.Format == "console" {
 		consoleHandler := NewConsoleHandler(output, opts)
 		// Color for now is set automatically depends on the stdout is PTY or not
-		//consoleHandler.SetUseColor(config.UseColor)
+		// consoleHandler.SetUseColor(config.UseColor)
 		handler = consoleHandler
 	} else {
 		handler = slog.NewJSONHandler(output, opts)


### PR DESCRIPTION
Keeping removal operations of ApplicationState from sending to subscribers.
Also fixes a bit of console issue when printing out errors.

## Related Issue

Fixes: #137 

## Motivation and Context

Never surrender!

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

